### PR TITLE
Update README.md to remove "-o" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Terraform provider for oneview
   git clone https://github.com/HewlettPackard/terraform-provider-oneview.git
   cd terraform-provider-oneview
   go get
-  go build -o terraform-provider-oneview
+  go build
   mv terraform-provider-oneview /usr/local/bin/terraform
 ```
 


### PR DESCRIPTION
This option makes it so it can be only built on UNIX environments. If you remove `-o terraform-provider-oneview` but you still keep the `go build`, it will create the binary file in the folder where `go build` was executed, and the binary name will have the same name as the folder and if it requires extension, Go will give it one.