### PR TITLE
add new attribute deploy_net_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # terraform-provider-oneview
 A Terraform provider for oneview
 
-## Installation 
+## Installation
 
 * Install golang 1.7 or better
 * Install Terraform 0.8.0 or better
@@ -28,8 +28,8 @@ provider "oneview" {
 resource "oneview_server_profile" "default" {
   name              = "test"
   template          = "Web Server Template"
-  
-  //specify this value so icsp can find the public ip address. 
+
+  //specify this value so icsp can find the public ip address.
   public_connection = "pub_conn_1"
 }
 
@@ -39,7 +39,7 @@ resource "icsp_server" "default" {
   password = "ilo_password"
   serial_number = "${oneview_server_profile.default.serial_number}"
   build_plans = ["/rest/os-deployment-build-plans/1570001"]
-  
+
   //this attribute gets you the public ip address
   public_mac = "${oneview_server_profile.default.public_mac}"
 }
@@ -47,7 +47,7 @@ resource "icsp_server" "default" {
 More information about how to configure the provider can be found [here](https://github.com/HewlettPackard/terraform-provider-oneview/blob/master/docs/index.html.markdown)
 
 ## Resources
-Any resource that OneView can manage is on the roadmap for Terraform to also manage. Below is the current list of resources that Terraform can manage. Open an issue if there is a resource that needs to be developed as soon as possible. 
+Any resource that OneView can manage is on the roadmap for Terraform to also manage. Below is the current list of resources that Terraform can manage. Open an issue if there is a resource that needs to be developed as soon as possible.
 
 ####[Server Profile](https://github.com/HewlettPackard/terraform-provider-oneview/blob/master/docs/r/server_profile.html.markdown)
 
@@ -59,7 +59,7 @@ resource "oneview_server_profile" "default" {
 ```
 
 ####[ICSP Server](https://github.com/HewlettPackard/terraform-provider-oneview/blob/master/docs/r/icsp_server.html.markdown)
-This block takes an already provsioned server and through ICSP lays down an operating system or 
+This block takes an already provsioned server and through ICSP lays down an operating system or
 whatever is specified in the build plans.
 
 ```js
@@ -73,12 +73,13 @@ resource "icsp_server" "default" {
 ```
 
 ####[Image Streamer Deployment Plan](https://github.com/HewlettPackard/terraform-provider-oneview/blob/master/docs/r/i3s_plan.html.markdown)
-This block takes an already provisioned server and through Image Streamer lays down an Operating System. 
+This block takes an already provisioned server and through Image Streamer lays down an Operating System.
 
 ```js
 resource "oneview_i3s_plan" "default" {
   server_name = "${oneview_server_profile.default.name}"
   os_deployment_plan = "Ubuntu 16.04"
+  deploy_net_name = "I3S-Deploy-v301"
 }
 ```
 
@@ -134,14 +135,14 @@ resource "oneview_network_set" "default" {
 ```js
 resource "oneview_logical_interconnect_group" "default" {
   name = "test-logical-interconnect-group"
-  
+
   internal_network_uris = ["${oneview_ethernet_network.default.0.uri}"]
-  
+
   interconnect_map_entry_template {
     interconnect_type_name = "HP VC FlexFabric-20/40 F8 Module"
     bay_number = 1
   }
-  
+
   uplink_set {
     name = "uplink-default"
     network_uris = ["${oneview_ethernet_network.test.1.uri}"]
@@ -158,7 +159,7 @@ resource "oneview_logical_interconnect_group" "default" {
 ```js
 resource "oneview_enclosure_group" "default" {
   name = "default-enclosure-group"
-  logical_interconnect_groups = ["${oneview_logical_interconnect_group.primary.name}", 
+  logical_interconnect_groups = ["${oneview_logical_interconnect_group.primary.name}",
                                  "${oneview_logical_interconnect_group.secondary.name}"]
 }
 ```

--- a/docs/r/i3s_plan.html.markdown
+++ b/docs/r/i3s_plan.html.markdown
@@ -16,26 +16,27 @@ Adds a deployment plan to a server.
 resource "oneview_i3s_plan" "default" {
   server_name = "${oneview_server_profile.default.name}"
   os_deployment_plan = "Ubuntu 16.04"
+  deploy_net_name = "I3S-Deploy-v301"
 }
 ```
 
 ## Argument Reference
 
-The following arguments are supported: 
+The following arguments are supported:
 
 * `server_name` - (Required) The name of the server that the deployment plan will be run on.
 
-* `os_deployment_plan` - (Required) The name of the deployment plan that will run on the server. 
+* `os_deployment_plan` - (Required) The name of the deployment plan that will run on the server.
+
+* `deploy_net_name` - (Required) The name of ethernet network for deployment network.
 
 - - -
 
 * `deployment_attribute` - (Optional) A key/value pair that modifies the default values provided by the os deployment plan
   This can be specified multiple times. Deployment Attribute is described below.
-  
+
 Deployment Attribute supports the following:
 
 * `key` - (Required) - The unique name of the attribute.
 
 * `value` - (Required) - The value of the attribute.
-
-

--- a/oneview/resource_i3s_plan.go
+++ b/oneview/resource_i3s_plan.go
@@ -13,6 +13,7 @@ package oneview
 
 import (
 	"fmt"
+
 	"github.com/HewlettPackard/oneview-golang/ov"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -30,6 +31,10 @@ func resourceI3SPlan() *schema.Resource {
 				Required: true,
 			},
 			"os_deployment_plan": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"deploy_net_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -60,6 +65,7 @@ func resourceI3SPlanCreate(d *schema.ResourceData, meta interface{}) error {
 	customizeServer := ov.CustomizeServer{
 		ProfileName:           d.Get("server_name").(string),
 		OSDeploymentBuildPlan: d.Get("os_deployment_plan").(string),
+		EthernetNetworkName:   d.Get("deploy_net_name").(string),
 	}
 
 	if _, ok := d.GetOk("deployment_attribute"); ok {


### PR DESCRIPTION
This removes the reqirement to have the deployment network called
deploy.net.   This change depends on the following PR being merged:

https://github.com/HewlettPackard/oneview-golang/pull/102