### PR TITLE
Our builds stopped working because latest is no longer working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 language: go
 go:
-- 1.7
+- 1.8
 install:
 - go get github.com/mattn/goveralls
 - go get -u github.com/golang/lint/golint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,33 @@
-FROM golang:alpine
+FROM golang:1.8.0-alpine
 
 RUN apk add --update git make sudo unzip wget openssh
 
 ADD . /go/src/github.com/HewlettPackard/terraform-provider-oneview
 
-RUN wget --no-check-certificate https://releases.hashicorp.com/terraform/0.6.16/terraform_0.6.16_linux_amd64.zip && \
-    unzip terraform_0.6.16_linux_amd64.zip -d /usr/local/terraform && \
-    rm terraform_0.6.16_linux_amd64.zip && \
-    rm /usr/local/terraform/terraform-provider-* && \
-    rm /usr/local/terraform/terraform-provisioner-chef
+ENV GLIDE_VERSION 0.12.1
+ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/v${GLIDE_VERSION}/glide-v${GLIDE_VERSION}-linux-amd64.tar.gz
 
+ENV TERRAFORM_VERSION 0.8.8
+ENV TERRAFORM_DOWNLOAD_URL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
+# Install terraform binary
+RUN wget --no-check-certificate ${TERRAFORM_DOWNLOAD_URL} -O terraform_linux_amd64.zip && \
+    unzip terraform_linux_amd64.zip -d /usr/local/terraform && \
+    rm terraform_linux_amd64.zip && \
+    find /usr/local/terraform
+#    rm /usr/local/terraform/terraform-provider-* && \
+#    rm /usr/local/terraform/terraform-provisioner-chef
+
+# Install glide tools
+RUN wget --no-check-certificate "$GLIDE_DOWNLOAD_URL" -O glide.tar.gz \
+    && tar -xzf glide.tar.gz \
+    && mv linux-amd64/glide /usr/bin/ \
+    && rm -r linux-amd64 \
+    && rm glide.tar.gz
+
+# Build the plugin
 RUN mkdir -p /go/src/github.com/HewlettPackard/ && \
     cd /go/src/github.com/HewlettPackard/terraform-provider-oneview && \
-    wget --no-check-certificate https://glide.sh/get -O ./glide.sh && \
-    ls -altr; chmod +x ./glide.sh && \
-    sh ./glide.sh && \
     glide install && \
     CGO_ENABLED=0 go build -a -installsuffix cgo -o terraform-provider-oneview && \
     mv terraform-provider-oneview /usr/local/terraform/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM golang:alpine
 
 RUN apk add --update git make sudo unzip wget openssh
 
+ADD . /go/src/github.com/HewlettPackard/terraform-provider-oneview
+
 RUN wget --no-check-certificate https://releases.hashicorp.com/terraform/0.6.16/terraform_0.6.16_linux_amd64.zip && \
     unzip terraform_0.6.16_linux_amd64.zip -d /usr/local/terraform && \
     rm terraform_0.6.16_linux_amd64.zip && \
@@ -9,11 +11,11 @@ RUN wget --no-check-certificate https://releases.hashicorp.com/terraform/0.6.16/
     rm /usr/local/terraform/terraform-provisioner-chef
 
 RUN mkdir -p /go/src/github.com/HewlettPackard/ && \
-    cd /go/src/github.com/HewlettPackard && \
-    git clone https://github.com/HewlettPackard/terraform-provider-oneview.git && \
-    cd terraform-provider-oneview && \
-    git config --global http.sslVerify false && \
-    go get && \
+    cd /go/src/github.com/HewlettPackard/terraform-provider-oneview && \
+    wget --no-check-certificate https://glide.sh/get -O ./glide.sh && \
+    ls -altr; chmod +x ./glide.sh && \
+    sh ./glide.sh && \
+    glide install && \
     CGO_ENABLED=0 go build -a -installsuffix cgo -o terraform-provider-oneview && \
     mv terraform-provider-oneview /usr/local/terraform/ && \
     cd /go && \

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,17 @@
+package: .
+ignore:
+  - github.com/maximilien/softlayer-go
+  - github.com/docker/machine
+  - github.com/HewlettPackard/terraform-provider-oneview
+import:
+- package: github.com/HewlettPackard/oneview-golang
+  version: =0.8.2
+  subpackages:
+  - i3s
+  - icsp
+  - ov
+  - utils
+- package: github.com/hashicorp/terraform
+  version: =0.8.8
+  subpackages:
+  - plugin

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,13 +5,13 @@ ignore:
   - github.com/HewlettPackard/terraform-provider-oneview
 import:
 - package: github.com/HewlettPackard/oneview-golang
-  version: =0.8.2
+  version: ^0.8.2
   subpackages:
   - i3s
   - icsp
   - ov
   - utils
 - package: github.com/hashicorp/terraform
-  version: =0.8.8
+  version: ^0.8.8
   subpackages:
   - plugin


### PR DESCRIPTION
This PR switches us to using glide to build the plugin and pins on specific versions
of the libraries that we require for the plugin.

We'll also change the Dockerfile build process to use the current source for our
builds vs trying to git clone it from the remote repos.

Signed-off-by: Edward Raigosa <edward.raigosa@hpe.com>