### PR TITLE
Update travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ script:
   - if ! [ -z "$UNFORMATTED" ]; then
       echo -e "Go files must be formatted with gofmt. Please run:";
       for fn in $UNFORMATTED; do
-        echo -e "  gofmt -w $PWD/$fn"
-      done
-      exit 1
+        echo -e "  gofmt -w $PWD/$fn";
+      done;
+      exit 1;
     fi
   - go vet $(go list ./... | grep -v '/vendor/')
   - go test -v $(go list ./... | grep -v '/vendor/')

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,12 @@ go:
 
 env:
   global:
-    - COMMIT="commit-${TRAVIS_COMMIT::8}"
     - REPO=dciacoe/terraform-provider-oneview
-    - TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "travis-build-${TRAVIS_BRANCH}"; fi)
+    - TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "branch-${TRAVIS_BRANCH}"; fi)
 
 script:
-  - docker build -f Dockerfile -t $REPO:$COMMIT .
+  - docker build -f Dockerfile -t $REPO:$TAG .
 
 after_success:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-  - docker tag $REPO:$COMMIT $REPO:$TAG
   - docker push $REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - REPO=dciacoe/terraform-provider-oneview
     - TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "branch-${TRAVIS_BRANCH}"; fi)
-    - UNFORMATTED=$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))
+    - UNFORMATTED=`gofmt -l $(find . -type f -name "*.go" -not -path "./vendor/*")`
 
 install:
   - # an empty install saves the hassle of pseudo-getting deps (they're vendored, so no need!)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
     - REPO=dciacoe/terraform-provider-oneview
     - TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "branch-${TRAVIS_BRANCH}"; fi)
 
+install:
+  - # an empty install saves the hassle of pseudo-getting deps (they're vendored, so no need!)
+
 script:
   - docker build -f Dockerfile -t $REPO:$TAG .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ go:
 
 env:
   global:
-    - COMMIT=${TRAVIS_COMMIT::8}
+    - COMMIT="commit-${TRAVIS_COMMIT::8}"
     - REPO=dciacoe/terraform-provider-oneview
-    - TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "travis-build-${TRAVIS_BRANCH}"; fi`
+    - TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "travis-build-${TRAVIS_BRANCH}"; fi)
 
 script:
   - docker build -f Dockerfile -t $REPO:$COMMIT .

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - REPO=dciacoe/terraform-provider-oneview
     - TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "branch-${TRAVIS_BRANCH}"; fi)
-    - UNFORMATTED=`gofmt -l $(find . -type f -name "*.go" -not -path "./vendor/*")`
+    - UNFORMATTED=$(find . -type f -name "*.go" -not -path "./vendor/*" | xargs gofmt -l)
 
 install:
   - # an empty install saves the hassle of pseudo-getting deps (they're vendored, so no need!)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,14 @@ go:
 
 env:
   global:
-    - secure: "JJBNOjRJ11XyeuGd+IyVSG+UBn4gvM4j20pG7WVc49FkqJAwkbOEOHKxeqvDQMMPqdnJ4nn0PR+DDHMCifVmBnghiMF6mMlsbxfR8kRjBP7kOjgBkglW4iU4GDAmuxWIWREo3lYI/pc2Ub7mDpCA+nS2ExEpiwzeFhY9skXVDpJxf0uKcQDKHGkV6APdFLalwtcEKeSeZCZvJGMR48cJ725vZ3pW3JgH7a0fKFR2LnmIDKhWU5OL45dewoSu4HGmrC6mxIABf3MLTqItbbSoRhb1voz2iDd7QqXsCIQ9gc2uYYyQybSYi7ohVEh78fmF/zpFfQkN2UPEbidb0SgrJvGmrnX6MN+AT1hhbI6LFuPfCHVbYog6iwkkjo4Ys+uVTx8+LiOTdS+ufVS4Hi8daihuRXI9+3+DBkdF5ZvHDBgxe44oHiK6C52brcVL5/YcG0Q3QnRRpGlaItBttcgTBbZbX7UaJ/Rv2soJxTcrB5pHn7FxWL/zr4B7+XQRbGPWah4WHcEnaIexwcheYeUHVW5pcz6YMgLzOH7btPCiS98240o/0vrxOxv60rDLmWakkZ06stHd9sLYYKDNMsqhTWSNmbzC6n3dmICwRWXlFmywK9eAKpAIN67JgE2E5l/gUgccwh59nvSSj2BNyfG6uvJNGXuxncPJda/4NrV2x5Q="
-    - secure: "NGR5vzS4T1dJ/0kbVqFYwW6oThE7JH4UBFBAzEc7vT6h6NANmY1O+6ojRdmSvnTIjN4vxXZzWfhQTLW9T3pMAeEhyjfn2p2T5fFAf381Ch5fu2fuAbCMOm+gCgSg/FAkQ3qCCAzniPv0cHl7c76NvG6wcC+geVDZw6YmwZ6m3DZ8vT1hQLWZggSeFvNmCsYh6NTulKXxjYOmGGkAkfkzSZxHcFOaMhVYEnQrig4tT6DN0Cjeq089R2pyATSFen5eGzo6Othy/lWkZrd0WWBIj9cX49CL7vvzFtodRALdAC7+GxcNYgmJZWfbMFU6ud01VZ/C8BvBqsELkdxqGdlGr/GUXy9wLQfCp2PyfV9qOa6y8qBCVlbcHzO1WNFAORnJpoD9w5r+/50zQ3o2G/lsHv4+WytHjz1CdiGLUxEXDrjp1uGBWoFb+xR9yqfzH2c4wCoGQSBZkbDa8ESABsrNOc9ewsmStFeq4txmfCR/WmkW+Tr7Ylq5h1XXbzn6PnLvzvQ/dDkk9HdInfpfa4wuNm4k6/7/+gp4NxtHHNy6IudFNFG6Yzmap1Z0q00Mzi3DGFqgHupFB/Rv2Cw+40fcchtCF0KXSRD6eAXHH3pNGscY1hekEd7IbC4w9BkLUxb2q/g6fzP/is1ylBovsnoK5zMuADEPkp+AJHBvyM8tuVk="
-    - secure: "vb8LigJ62OtLmgkCDsPXrPKdIxpwu4pvTYWjhvHO1gTr2PHEg5cNkXbrcileY8uzsfc1qoIYX9xbteM4Gcu8UO160R4V47dXxSYs8i1FGPQnW1UmXpkEmfPPHLJUB0WesYXfveCypuWk9ydNVoveLEVdm5S57t29xUEx2taANBktuTSEro4cXD49n4uy/EVnZqPOuXc1qzng1RoEX6O2q3x/C+Sa+jaBo/2UtrwloHS25xOoHh4Lwq6bYQIZZfJaitQnbYxm6trcWcTlJH06qRAoRCvFrZkTvaAUvjO/Y2BNlgfbFTfD9mB7DNGK28T5U5Jd7dX7nq3SVVQfdS32xJAaUDG6gt9QvO2gDxe+xnp1745NS/PrBwrDeRiSrv2bubNua+h1bJz6K5D9horkWuL+S9MI4IV4dBADrG4gFqzXQZESO5Zo8SGIkvwz7xzEr1cXRj3Tt73gU0LEvitXHjDuXtmsZYhRfCQqnWf4QQbieQGnUn0lkPtz4pfv17pxvGQ/fiHFq5bBHiKyn8dKMD2Wce8Xbt7pGucQRmUhoPbvET8h/CyiT3QDiQu9qZbiO+vzNbC5yh8FAwx69ehgzRiJ/uWZ5Thoc0gtrWq7lJgVlB6BP7m9zpTN46a2ug4v0oZ7oPJFNgfjwRqnIkILhuGdaP4CyedH344djywe+0c="
     - COMMIT=${TRAVIS_COMMIT::8}
+    - REPO=dciacoe/terraform-provider-oneview
+    - TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "travis-build-${TRAVIS_BRANCH}"; fi`
+
+script:
+  - docker build -f Dockerfile -t $REPO:$COMMIT .
 
 after_success:
-  - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-  - export REPO=mbfrahry/terraform-provider-oneview
-  - export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
-  - docker build -f Dockerfile -t $REPO:$COMMIT .
+  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
   - docker tag $REPO:$COMMIT $REPO:$TAG
-  - docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
   - docker push $REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - # an empty install saves the hassle of pseudo-getting deps (they're vendored, so no need!)
 
 script:
+  - go test -v ./...
   - docker build -f Dockerfile -t $REPO:$TAG .
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,21 @@ env:
   global:
     - REPO=dciacoe/terraform-provider-oneview
     - TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "branch-${TRAVIS_BRANCH}"; fi)
+    - UNFORMATTED=$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))
 
 install:
   - # an empty install saves the hassle of pseudo-getting deps (they're vendored, so no need!)
 
 script:
-  - go test -v ./...
+  - if ! [ -z "$UNFORMATTED" ]; then
+      echo -e "Go files must be formatted with gofmt. Please run:";
+      for fn in $UNFORMATTED; do
+        echo -e "  gofmt -w $PWD/$fn"
+      done
+      exit 1
+    fi
+  - go vet $(go list ./... | grep -v '/vendor/')
+  - go test -v $(go list ./... | grep -v '/vendor/')
   - docker build -f Dockerfile -t $REPO:$TAG .
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - REPO=dciacoe/terraform-provider-oneview
     - TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo "branch-${TRAVIS_BRANCH}"; fi)
-    - UNFORMATTED=$(find . -type f -name "*.go" -not -path "./vendor/*" | xargs gofmt -l)
+    - UNFORMATTED=$(find . -type f -name "*.go" -not -path "./vendor/*" | sed "s|^\./||" | xargs gofmt -l)
 
 install:
   - # an empty install saves the hassle of pseudo-getting deps (they're vendored, so no need!)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # terraform-provider-oneview
 
+[![Build Status](https://travis-ci.org/HewlettPackard/terraform-provider-oneview.svg?branch=master)](https://travis-ci.org/HewlettPackard/terraform-provider-oneview)
+
 A Terraform provider for oneview
 
 ## Installation

--- a/main.go
+++ b/main.go
@@ -12,14 +12,12 @@
 package main
 
 import (
-    "github.com/hashicorp/terraform/plugin"
-    "github.com/HewlettPackard/terraform-provider-oneview/oneview"
+	"github.com/HewlettPackard/terraform-provider-oneview/oneview"
+	"github.com/hashicorp/terraform/plugin"
 )
 
 func main() {
-  plugin.Serve(&plugin.ServeOpts{
-  	ProviderFunc:	oneview.Provider,
-  })
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: oneview.Provider,
+	})
 }
- 
-


### PR DESCRIPTION
Hello everyone,

This is an update to the travis build process to test Pull Requests and Branches in the Travis CI pipeline.

The following changes were made:

- [x] Removed hardcoded secure variables and instead they're available to whoever has admin / org access inside the Travis control panel. This allows to run the travis CLI locally and still get the benefit of pushing stuff to another account if needed. This also changes the username and password used to publish the Docker containers (again, thanks @mbfrahry!)
- [x] Adds `gofmt` to the repository and enforces it. This is because [terraform itself has it](https://github.com/hashicorp/terraform/blob/master/.github/CONTRIBUTING.md#running-an-acceptance-test) as a part of their acceptance tests.
- [x] Adds `go vet` and `go test` without actually testing or vetting dependencies.
- [x] Allows to test if the docker container does build
- [x] Pushes every successful merge to master as "latest" in Docker Hub under `dciacoe/terraform-provider-oneview`
- [x] Pushes [on-development docker images](https://hub.docker.com/r/dciacoe/terraform-provider-oneview/tags/) as `dciacoe/terraform-provider-oneview:branch-$BRANCH_NAME` so you can download development branch images from the Docker hub, [rather than posting every single commit and every single PR and every single branch](https://hub.docker.com/r/mbfrahry/terraform-provider-oneview/tags/).

Let me know your thoughts!