### PR TITLE
Removed shadow variables and unused structures

### DIFF
--- a/oneview/config.go
+++ b/oneview/config.go
@@ -12,6 +12,8 @@
 package oneview
 
 import (
+	"errors"
+
 	"github.com/HewlettPackard/oneview-golang/i3s"
 	"github.com/HewlettPackard/oneview-golang/icsp"
 	"github.com/HewlettPackard/oneview-golang/ov"
@@ -39,44 +41,49 @@ type Config struct {
 	i3sClient  *i3s.I3SClient
 }
 
-func (c *Config) loadAndValidate() error {
-	var client2 *ov.OVClient
+var ErrConfigNotInitialized = errors.New("config not initialized!")
 
-	client := client2.NewOVClient(c.OVUsername, c.OVPassword, c.OVDomain, c.OVEndpoint, c.OVSSLVerify, c.OVAPIVersion)
+func (c *Config) loadAndValidate() error {
+	if c == nil {
+		return ErrConfigNotInitialized
+	}
+
+	client := (&ov.OVClient{}).NewOVClient(c.OVUsername, c.OVPassword, c.OVDomain, c.OVEndpoint, c.OVSSLVerify, c.OVAPIVersion)
 
 	c.ovClient = client
 
-	session, error := c.ovClient.SessionLogin()
-	c.ovClient.APIKey = session.ID
-
-	if error != nil {
-		return error
+	session, err := c.ovClient.SessionLogin()
+	if err != nil {
+		return err
 	}
+
+	c.ovClient.APIKey = session.ID
 
 	return nil
 }
 
 func (c *Config) loadAndValidateICSP() error {
+	if c == nil {
+		return ErrConfigNotInitialized
+	}
 
-	var client2 *icsp.ICSPClient
-
-	client := client2.NewICSPClient(c.ICSPUsername, c.ICSPPassword, c.ICSPDomain, c.ICSPEndpoint, c.ICSPSSLVerify, c.ICSPAPIVersion)
+	client := (&icsp.ICSPClient{}).NewICSPClient(c.ICSPUsername, c.ICSPPassword, c.ICSPDomain, c.ICSPEndpoint, c.ICSPSSLVerify, c.ICSPAPIVersion)
 
 	c.icspClient = client
 
-	_, error := c.icspClient.SessionLogin()
-	if error != nil {
-		return error
+	if _, err := c.icspClient.SessionLogin(); err != nil {
+		return err
 	}
 
 	return nil
 }
 
 func (c *Config) loadAndValidateI3S() error {
+	if c == nil {
+		return ErrConfigNotInitialized
+	}
 
-	var client3 *i3s.I3SClient
-
-	client := client3.NewI3SClient(c.I3SEndpoint, c.OVSSLVerify, c.OVAPIVersion, c.ovClient.APIKey)
+	client := (&i3s.I3SClient{}).NewI3SClient(c.I3SEndpoint, c.OVSSLVerify, c.OVAPIVersion, c.ovClient.APIKey)
 
 	c.i3sClient = client
 

--- a/oneview/provider.go
+++ b/oneview/provider.go
@@ -17,8 +17,10 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-var ovMutexKV = mutexkv.NewMutexKV()
-var serverHardwareURIs map[string]bool = make(map[string]bool)
+var (
+	ovMutexKV          = mutexkv.NewMutexKV()
+	serverHardwareURIs = make(map[string]bool)
+)
 
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{

--- a/oneview/resource_ethernet_network.go
+++ b/oneview/resource_ethernet_network.go
@@ -180,9 +180,9 @@ func resourceEthernetNetworkUpdate(d *schema.ResourceData, meta interface{}) err
 func resourceEthernetNetworkDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	error := config.ovClient.DeleteEthernetNetwork(d.Get("name").(string))
-	if error != nil {
-		return error
+	err := config.ovClient.DeleteEthernetNetwork(d.Get("name").(string))
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/oneview/resource_fc_network.go
+++ b/oneview/resource_fc_network.go
@@ -114,8 +114,8 @@ func resourceFCNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceFCNetworkRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	fcNet, error := config.ovClient.GetFCNetworkByName(d.Get("name").(string))
-	if error != nil || fcNet.URI.IsNil() {
+	fcNet, err := config.ovClient.GetFCNetworkByName(d.Get("name").(string))
+	if err != nil || fcNet.URI.IsNil() {
 		d.SetId("")
 		return nil
 	}
@@ -164,9 +164,9 @@ func resourceFCNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceFCNetworkDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	error := config.ovClient.DeleteFCNetwork(d.Get("name").(string))
-	if error != nil {
-		return error
+	err := config.ovClient.DeleteFCNetwork(d.Get("name").(string))
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/oneview/resource_fcoe_network.go
+++ b/oneview/resource_fcoe_network.go
@@ -152,9 +152,9 @@ func resourceFCoENetworkUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceFCoENetworkDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	error := config.ovClient.DeleteFCoENetwork(d.Get("name").(string))
-	if error != nil {
-		return error
+	err := config.ovClient.DeleteFCoENetwork(d.Get("name").(string))
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/oneview/resource_i3s_plan.go
+++ b/oneview/resource_i3s_plan.go
@@ -126,9 +126,9 @@ func resourceI3SPlanRead(d *schema.ResourceData, meta interface{}) error {
 func resourceI3SPlanUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	error := config.ovClient.DeleteOSBuildPlanFromServer(d.Get("server_name").(string))
-	if error != nil {
-		return error
+	err := config.ovClient.DeleteOSBuildPlanFromServer(d.Get("server_name").(string))
+	if err != nil {
+		return err
 	}
 
 	customizeServer := ov.CustomizeServer{
@@ -147,7 +147,7 @@ func resourceI3SPlanUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(d.Get("server_name").(string))
-	err := config.ovClient.CustomizeServer(customizeServer)
+	err = config.ovClient.CustomizeServer(customizeServer)
 	if err != nil {
 		d.SetId("")
 		return err
@@ -159,9 +159,9 @@ func resourceI3SPlanUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceI3SPlanDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	error := config.ovClient.DeleteOSBuildPlanFromServer(d.Get("server_name").(string))
-	if error != nil {
-		return error
+	err := config.ovClient.DeleteOSBuildPlanFromServer(d.Get("server_name").(string))
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/oneview/resource_icsp_server.go
+++ b/oneview/resource_icsp_server.go
@@ -13,6 +13,7 @@ package oneview
 
 import (
 	"fmt"
+
 	"github.com/HewlettPackard/oneview-golang/icsp"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -237,9 +238,9 @@ func resourceIcspServerUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceIcspServerDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	isDel, error := config.icspClient.DeleteServer(d.Get("mid").(string))
-	if error != nil {
-		return error
+	isDel, err := config.icspClient.DeleteServer(d.Get("mid").(string))
+	if err != nil {
+		return err
 	}
 	if !isDel {
 		return fmt.Errorf("Could not delete server")

--- a/oneview/resource_logical_interconnect_group.go
+++ b/oneview/resource_logical_interconnect_group.go
@@ -13,11 +13,12 @@ package oneview
 
 import (
 	"fmt"
+	"reflect"
+	"strconv"
+
 	"github.com/HewlettPackard/oneview-golang/ov"
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/hashicorp/terraform/helper/schema"
-	"reflect"
-	"strconv"
 )
 
 func resourceLogicalInterconnectGroup() *schema.Resource {
@@ -1085,9 +1086,9 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 func resourceLogicalInterconnectGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	error := config.ovClient.DeleteLogicalInterconnectGroup(d.Get("name").(string))
-	if error != nil {
-		return error
+	err := config.ovClient.DeleteLogicalInterconnectGroup(d.Get("name").(string))
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/oneview/resource_logical_switch_group.go
+++ b/oneview/resource_logical_switch_group.go
@@ -13,6 +13,7 @@ package oneview
 
 import (
 	"fmt"
+
 	"github.com/HewlettPackard/oneview-golang/ov"
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -170,9 +171,9 @@ func resourceLogicalSwitchGroupRead(d *schema.ResourceData, meta interface{}) er
 func resourceLogicalSwitchGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	error := config.ovClient.DeleteLogicalSwitchGroup(d.Get("name").(string))
-	if error != nil {
-		return error
+	err := config.ovClient.DeleteLogicalSwitchGroup(d.Get("name").(string))
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/oneview/resource_network_set.go
+++ b/oneview/resource_network_set.go
@@ -179,9 +179,9 @@ func resourceNetworkSetUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceNetworkSetDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	error := config.ovClient.DeleteNetworkSet(d.Get("name").(string))
-	if error != nil {
-		return error
+	err := config.ovClient.DeleteNetworkSet(d.Get("name").(string))
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/oneview/resource_server_profile_template.go
+++ b/oneview/resource_server_profile_template.go
@@ -323,9 +323,9 @@ func resourceServerProfileTemplateUpdate(d *schema.ResourceData, meta interface{
 func resourceServerProfileTemplateDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	error := config.ovClient.DeleteProfileTemplate(d.Get("name").(string))
-	if error != nil {
-		return error
+	err := config.ovClient.DeleteProfileTemplate(d.Get("name").(string))
+	if err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
This PR:

* Removes the need in `config.go` to have a second variable to initialize the first one. This uses a variable that Go runtime can discard quickly once used. Further change to this logic may be required on `oneview-golang` SDK.
* Changes several variables called `error`. This is considered a shadow variable because other developers may want to use the interface `error` (which we can say it's a type, although it's an interface) rather than the variable name later on. Incidences of this thing are small, but it's better not to have a variable named like a built-in package.
* Checks in the config part if the structure is initialized. With no check at all, the app will panic and crash if the method is called. Maybe it's not needed but the configuration already returns an error, so we can use that to double-check it.