### PR TITLE
Updated Eth-Net docs with vlan_id instead of vlanId

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ resource "oneview_server_profile_template" "default" {
 ```js
 resource "oneview_ethernet_network" "default" {
   name = "test-ethernet-network"
-  vlanId = 71
+  vlan_id = 71
 }
 ```
 

--- a/docs/r/ethernet_network.html.markdown
+++ b/docs/r/ethernet_network.html.markdown
@@ -15,31 +15,31 @@ Creates an ethernet network.
 ```js
 resource "oneview_ethernet_network" "default" {
   name = "test-ethernet-network"
-  vlanId = 71
+  vlan_id = 71
 }
 ```
 
 ## Argument Reference
 
-The following arguments are supported: 
+The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource.
 
-* `vlanId` - (Required) The Virtual LAN (VLAN) identification number (integer) assigned to the network. 
+* `vlan_id` - (Required) The Virtual LAN (VLAN) identification number (integer) assigned to the network.
 Changing this forces a new resource.
 
 - - -
 
-* `purpose` - (Optional) A description of the network's role within the logical interconnect. 
+* `purpose` - (Optional) A description of the network's role within the logical interconnect.
   This defaults to General.
-  
-* `private_network` - (Optional) When enabled, the network is configured so that all downlink (server) ports 
+
+* `private_network` - (Optional) When enabled, the network is configured so that all downlink (server) ports
   connected to the network are prevented from communicating with each other within the logical interconnect.
   This defaults to false.
 
-* `smart_link` - (Optional) When enabled, the network is configured so that, within a logical interconnect, 
+* `smart_link` - (Optional) When enabled, the network is configured so that, within a logical interconnect,
   all uplinks that carry the network are monitored. This defaults to false.
-  
+
 * `ethernet_network_type` - (Optional) The type of Ethernet network. This defaults to Tagged.
 
 ## Attributes Reference

--- a/oneview/resource_ethernet_network_test.go
+++ b/oneview/resource_ethernet_network_test.go
@@ -90,5 +90,5 @@ func testAccCheckEthernetNetworkDestroy(s *terraform.State) error {
 var testAccEthernetNetwork = `
   resource "oneview_ethernet_network" "test" {
     name = "Terraform Ethernet Network 1"
-    vlanId = "${117}"
+    vlan_id = "${117}"
   }`


### PR DESCRIPTION
This just updates the docs to match the actual code, but it brings up a bigger question/issue: which format (snake_case or camelCase) we want to standardize on for resource properties. It's all over the place right now; for instance, the ethernet network resource uses `vlan_id` but the fcoe resoruce uses `vlanId`. Personally, I'd rather stick with camelCase because the OneView API uses it, so it will be easier to map the properties to the API docs, but I'm not thrilled about changing everything at this point because it'll break people's code if they update :(