### PR TITLE
Add import support to all resources

### DIFF
--- a/oneview/resource_ethernet_network.go
+++ b/oneview/resource_ethernet_network.go
@@ -23,6 +23,9 @@ func resourceEthernetNetwork() *schema.Resource {
 		Read:   resourceEthernetNetworkRead,
 		Update: resourceEthernetNetworkUpdate,
 		Delete: resourceEthernetNetworkDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/oneview/resource_ethernet_network_test.go
+++ b/oneview/resource_ethernet_network_test.go
@@ -38,6 +38,11 @@ func TestAccEthernetNetwork_1(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:      testAccEthernetNetwork,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/oneview/resource_fc_network.go
+++ b/oneview/resource_fc_network.go
@@ -24,8 +24,8 @@ func resourceFCNetwork() *schema.Resource {
 		Update: resourceFCNetworkUpdate,
 		Delete: resourceFCNetworkDelete,
 		Importer: &schema.ResourceImporter{
-                        State: schema.ImportStatePassthrough,
-                },
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/oneview/resource_fc_network.go
+++ b/oneview/resource_fc_network.go
@@ -23,6 +23,9 @@ func resourceFCNetwork() *schema.Resource {
 		Read:   resourceFCNetworkRead,
 		Update: resourceFCNetworkUpdate,
 		Delete: resourceFCNetworkDelete,
+		Importer: &schema.ResourceImporter{
+                        State: schema.ImportStatePassthrough,
+                },
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -114,7 +117,7 @@ func resourceFCNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceFCNetworkRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	fcNet, err := config.ovClient.GetFCNetworkByName(d.Get("name").(string))
+	fcNet, err := config.ovClient.GetFCNetworkByName(d.Id())
 	if err != nil || fcNet.URI.IsNil() {
 		d.SetId("")
 		return nil

--- a/oneview/resource_fc_network_test.go
+++ b/oneview/resource_fc_network_test.go
@@ -39,10 +39,10 @@ func TestAccFCNetwork_1(t *testing.T) {
 				),
 			},
 			{
-                                ResourceName:      testAccFCNetwork,
-                                ImportState:       true,
-                                ImportStateVerify: true,
-                        },
+				ResourceName:      testAccFCNetwork,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/oneview/resource_fc_network_test.go
+++ b/oneview/resource_fc_network_test.go
@@ -38,6 +38,11 @@ func TestAccFCNetwork_1(t *testing.T) {
 					),
 				),
 			},
+			{
+                                ResourceName:      testAccFCNetwork,
+                                ImportState:       true,
+                                ImportStateVerify: true,
+                        },
 		},
 	})
 }

--- a/oneview/resource_fcoe_network.go
+++ b/oneview/resource_fcoe_network.go
@@ -23,6 +23,9 @@ func resourceFCoENetwork() *schema.Resource {
 		Read:   resourceFCoENetworkRead,
 		Update: resourceFCoENetworkUpdate,
 		Delete: resourceFCoENetworkDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/oneview/resource_fcoe_network_test.go
+++ b/oneview/resource_fcoe_network_test.go
@@ -38,6 +38,11 @@ func TestAccFCoENetwork_1(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:      testAccFCoENetwork,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/oneview/resource_i3s_plan.go
+++ b/oneview/resource_i3s_plan.go
@@ -24,6 +24,9 @@ func resourceI3SPlan() *schema.Resource {
 		Read:   resourceI3SPlanRead,
 		Update: resourceI3SPlanUpdate,
 		Delete: resourceI3SPlanDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"server_name": {

--- a/oneview/resource_i3s_plan_test.go
+++ b/oneview/resource_i3s_plan_test.go
@@ -38,6 +38,11 @@ func TestAccI3SPlan_1(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:      testAccI3SPlan,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/oneview/resource_icsp_server.go
+++ b/oneview/resource_icsp_server.go
@@ -24,6 +24,9 @@ func resourceIcspServer() *schema.Resource {
 		Read:   resourceIcspServerRead,
 		Update: resourceIcspServerUpdate,
 		Delete: resourceIcspServerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"type": {

--- a/oneview/resource_icsp_server_test.go
+++ b/oneview/resource_icsp_server_test.go
@@ -34,6 +34,11 @@ func TestAccICSP_Server_1(t *testing.T) {
 					testAccCheckICSPServerExists(
 						"oneview_icsp_server.test", &icspServer)),
 			},
+			{
+				ResourceName:      testAccICSPServer,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/oneview/resource_logical_interconnect_group.go
+++ b/oneview/resource_logical_interconnect_group.go
@@ -27,6 +27,9 @@ func resourceLogicalInterconnectGroup() *schema.Resource {
 		Read:   resourceLogicalInterconnectGroupRead,
 		Update: resourceLogicalInterconnectGroupUpdate,
 		Delete: resourceLogicalInterconnectGroupDelete,
+		Importer: &schema.ResourceImporter{
+                        State: schema.ImportStatePassthrough,
+                },
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/oneview/resource_logical_interconnect_group.go
+++ b/oneview/resource_logical_interconnect_group.go
@@ -28,8 +28,8 @@ func resourceLogicalInterconnectGroup() *schema.Resource {
 		Update: resourceLogicalInterconnectGroupUpdate,
 		Delete: resourceLogicalInterconnectGroupDelete,
 		Importer: &schema.ResourceImporter{
-                        State: schema.ImportStatePassthrough,
-                },
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/oneview/resource_logical_interconnect_group_test.go
+++ b/oneview/resource_logical_interconnect_group_test.go
@@ -39,10 +39,10 @@ func TestAccLogicalInterconnectGroup_1(t *testing.T) {
 				),
 			},
 			{
-                                ResourceName:      testAccLogicalInterconnectGroup,
-                                ImportState:       true,
-                                ImportStateVerify: true,
-                        },
+				ResourceName:      testAccLogicalInterconnectGroup,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/oneview/resource_logical_interconnect_group_test.go
+++ b/oneview/resource_logical_interconnect_group_test.go
@@ -38,6 +38,11 @@ func TestAccLogicalInterconnectGroup_1(t *testing.T) {
 					),
 				),
 			},
+			{
+                                ResourceName:      testAccLogicalInterconnectGroup,
+                                ImportState:       true,
+                                ImportStateVerify: true,
+                        },
 		},
 	})
 }

--- a/oneview/resource_logical_switch_group.go
+++ b/oneview/resource_logical_switch_group.go
@@ -25,6 +25,9 @@ func resourceLogicalSwitchGroup() *schema.Resource {
 		Read:   resourceLogicalSwitchGroupRead,
 		Update: resourceLogicalSwitchGroupUpdate,
 		Delete: resourceLogicalSwitchGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/oneview/resource_logical_switch_group_test.go
+++ b/oneview/resource_logical_switch_group_test.go
@@ -38,6 +38,11 @@ func TestAccLogicalSwitchGroup_1(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:      testAccLogicalSwitchGroup,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/oneview/resource_network_set.go
+++ b/oneview/resource_network_set.go
@@ -23,6 +23,9 @@ func resourceNetworkSet() *schema.Resource {
 		Read:   resourceNetworkSetRead,
 		Update: resourceNetworkSetUpdate,
 		Delete: resourceNetworkSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/oneview/resource_network_set_test.go
+++ b/oneview/resource_network_set_test.go
@@ -38,6 +38,11 @@ func TestAccNetworkSet_1(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:      testAccNetworkSet,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/oneview/resource_server_profile.go
+++ b/oneview/resource_server_profile.go
@@ -26,6 +26,9 @@ func resourceServerProfile() *schema.Resource {
 		Read:   resourceServerProfileRead,
 		Update: resourceServerProfileUpdate,
 		Delete: resourceServerProfileDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/oneview/resource_server_profile_template.go
+++ b/oneview/resource_server_profile_template.go
@@ -26,6 +26,9 @@ func resourceServerProfileTemplate() *schema.Resource {
 		Read:   resourceServerProfileTemplateRead,
 		Update: resourceServerProfileTemplateUpdate,
 		Delete: resourceServerProfileTemplateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/oneview/resource_server_profile_template_test.go
+++ b/oneview/resource_server_profile_template_test.go
@@ -38,6 +38,11 @@ func TestAccServerProfileTemplate_1(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:      testAccServerProfileTemplate,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/oneview/resource_server_profile_test.go
+++ b/oneview/resource_server_profile_test.go
@@ -37,6 +37,11 @@ func TestAccServerProfile_1(t *testing.T) {
 						"oneview_server_profile.test", "name", "test"),
 				),
 			},
+			{
+				ResourceName:      testAccServerProfile,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
#53 provided some great tips in implementing import support.  We recently acquired a Synergy system and are evaluating deployments with Ansible and Terraform.

I was able to successfully import:

- oneview_ethernet_network
- oneview_fc_network
- oneview_logical_interconnect_group
- oneview_network_set

These resources ran import ok, but did not put the `name` into the state file which causes some issues:

- oneview_server_profile
- oneview_server_profile_template

I was not able to test importing these resources in my environment:

- icsp_server
- oneview_i3s_plan
- oneview_fcoe_network
- oneview_logical_switch
- oneview_enclosure_group

oneview_enclosure_group seems to be broken in general though based on #46

I don't have a ton of experience with Go or Terraform, so I'm not sure if I put the tests in the correct spot.