### PR TITLE
Add SNMP v3 configuration support to Logical Interconnect Group

### DIFF
--- a/docs/r/logical_interconnect_group.html.markdown
+++ b/docs/r/logical_interconnect_group.html.markdown
@@ -121,7 +121,10 @@ Telemetry Configuration supports the following:
 
 Snmp Configuration supports the following: 
 
-* `enabled` - (Optional) Enables SNMP. Defaults to true.
+* `enabled` - (Optional) Enables SNMP v1 and v2. Defaults to true.
+
+* `v3_enabled` - (Optional) Enables SNMP v3.  Defaults to false.  Must be set to true
+  for a Virtual Connect SE 40Gb F8 Module.
 
 * `read_community` - (Optional) Authentication string for read-only access.
   Defaults to public.

--- a/oneview/resource_logical_interconnect_group.go
+++ b/oneview/resource_logical_interconnect_group.go
@@ -201,6 +201,11 @@ func resourceLogicalInterconnectGroup() *schema.Resource {
 							Optional: true,
 							Default:  true,
 						},
+						"v3_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 						"type": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -623,6 +628,10 @@ func resourceLogicalInterconnectGroupCreate(d *schema.ResourceData, meta interfa
 	if val, ok := d.GetOk(snmpConfigPrefix + ".enabled"); ok {
 		enabled := val.(bool)
 		snmpConfiguration.Enabled = &enabled
+	}
+	if val, ok := d.GetOk(snmpConfigPrefix + ".v3_enabled"); ok {
+		v3Enabled := val.(bool)
+		snmpConfiguration.V3Enabled = &v3Enabled
 	}
 	if val, ok := d.GetOk(snmpConfigPrefix + ".read_community"); ok {
 		snmpConfiguration.ReadCommunity = val.(string)
@@ -1052,6 +1061,7 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 	snmpConfiguration := make([]map[string]interface{}, 0, 1)
 	snmpConfiguration = append(snmpConfiguration, map[string]interface{}{
 		"enabled":          *logicalInterconnectGroup.SnmpConfiguration.Enabled,
+		"v3_enabled":       *logicalInterconnectGroup.SnmpConfiguration.V3Enabled,
 		"read_community":   logicalInterconnectGroup.SnmpConfiguration.ReadCommunity,
 		"snmp_access":      schema.NewSet(schema.HashString, snmpAccess),
 		"system_contact":   logicalInterconnectGroup.SnmpConfiguration.SystemContact,
@@ -1315,6 +1325,10 @@ func resourceLogicalInterconnectGroupUpdate(d *schema.ResourceData, meta interfa
 	if val, ok := d.GetOk(snmpConfigPrefix + ".enabled"); ok {
 		enabled := val.(bool)
 		snmpConfiguration.Enabled = &enabled
+	}
+	if val, ok := d.GetOk(snmpConfigPrefix + ".v3_enabled"); ok {
+		v3Enabled := val.(bool)
+		snmpConfiguration.V3Enabled = &v3Enabled
 	}
 	if val, ok := d.GetOk(snmpConfigPrefix + ".read_community"); ok {
 		snmpConfiguration.ReadCommunity = val.(string)

--- a/oneview/resource_logical_interconnect_group.go
+++ b/oneview/resource_logical_interconnect_group.go
@@ -516,10 +516,10 @@ func resourceLogicalInterconnectGroupCreate(d *schema.ResourceData, meta interfa
 	lig.InterconnectMapTemplate = &interconnectMapTemplate
 
 	uplinkSetCount := d.Get("uplink_set.#").(int)
-	uplinkSets := make([]ov.UplinkSet, 0)
+	uplinkSets := make([]ov.UplinkSets, 0)
 	for i := 0; i < uplinkSetCount; i++ {
 		uplinkSetPrefix := fmt.Sprintf("uplink_set.%d", i)
-		uplinkSet := ov.UplinkSet{}
+		uplinkSet := ov.UplinkSets{}
 		if val, ok := d.GetOk(uplinkSetPrefix + ".name"); ok {
 			uplinkSet.Name = val.(string)
 		}
@@ -1214,10 +1214,10 @@ func resourceLogicalInterconnectGroupUpdate(d *schema.ResourceData, meta interfa
 	lig.InterconnectMapTemplate = &interconnectMapTemplate
 
 	uplinkSetCount := d.Get("uplink_set.#").(int)
-	uplinkSets := make([]ov.UplinkSet, 0)
+	uplinkSets := make([]ov.UplinkSets, 0)
 	for i := 0; i < uplinkSetCount; i++ {
 		uplinkSetPrefix := fmt.Sprintf("uplink_set.%d", i)
-		uplinkSet := ov.UplinkSet{}
+		uplinkSet := ov.UplinkSets{}
 		if val, ok := d.GetOk(uplinkSetPrefix + ".name"); ok {
 			uplinkSet.Name = val.(string)
 		}

--- a/vendor/github.com/HewlettPackard/oneview-golang/ov/ethernet_network.go
+++ b/vendor/github.com/HewlettPackard/oneview-golang/ov/ethernet_network.go
@@ -9,23 +9,25 @@ import (
 )
 
 type EthernetNetwork struct {
-	Category              string        `json:"category,omitempty"`              // "category": "ethernet-networks",
-	ConnectionTemplateUri utils.Nstring `json:"connectionTemplateUri,omitempty"` // "connectionTemplateUri": "/rest/connection-templates/7769cae0-b680-435b-9b87-9b864c81657f",
-	Created               string        `json:"created,omitempty"`               // "created": "20150831T154835.250Z",
-	Description           utils.Nstring `json:"description,omitempty"`           // "description": "Ethernet network 1",
-	ETAG                  string        `json:"eTag,omitempty"`                  // "eTag": "1441036118675/8",
-	EthernetNetworkType   string        `json:"ethernetNetworkType,omitempty"`   // "ethernetNetworkType": "Tagged",
-	FabricUri             utils.Nstring `json:"fabricUri,omitempty"`             // "fabricUri": "/rest/fabrics/9b8f7ec0-52b3-475e-84f4-c4eac51c2c20",
-	Modified              string        `json:"modified,omitempty"`              // "modified": "20150831T154835.250Z",
-	Name                  string        `json:"name,omitempty"`                  // "name": "Ethernet Network 1",
-	PrivateNetwork        bool          `json:"privateNetwork"`                  // "privateNetwork": false,
-	Purpose               string        `json:"purpose,omitempty"`               // "purpose": "General",
-	SmartLink             bool          `json:"smartLink"`                       // "smartLink": false,
-	State                 string        `json:"state,omitempty"`                 // "state": "Normal",
-	Status                string        `json:"status,omitempty"`                // "status": "Critical",
-	Type                  string        `json:"type,omitempty"`                  // "type": "ethernet-networkV3",
-	URI                   utils.Nstring `json:"uri,omitempty"`                   // "uri": "/rest/ethernet-networks/e2f0031b-52bd-4223-9ac1-d91cb519d548"
-	VlanId                int           `json:"vlanId,omitempty"`                // "vlanId": 1,
+	Category              string          `json:"category,omitempty"`              // "category": "ethernet-networks",
+	ConnectionTemplateUri utils.Nstring   `json:"connectionTemplateUri,omitempty"` // "connectionTemplateUri": "/rest/connection-templates/7769cae0-b680-435b-9b87-9b864c81657f",
+	Created               string          `json:"created,omitempty"`               // "created": "20150831T154835.250Z",
+	Description           utils.Nstring   `json:"description,omitempty"`           // "description": "Ethernet network 1",
+	ETAG                  string          `json:"eTag,omitempty"`                  // "eTag": "1441036118675/8",
+	EthernetNetworkType   string          `json:"ethernetNetworkType,omitempty"`   // "ethernetNetworkType": "Tagged",
+	FabricUri             utils.Nstring   `json:"fabricUri,omitempty"`             // "fabricUri": "/rest/fabrics/9b8f7ec0-52b3-475e-84f4-c4eac51c2c20",
+	Modified              string          `json:"modified,omitempty"`              // "modified": "20150831T154835.250Z",
+	Name                  string          `json:"name,omitempty"`                  // "name": "Ethernet Network 1",
+	PrivateNetwork        bool            `json:"privateNetwork"`                  // "privateNetwork": false,
+	Purpose               string          `json:"purpose,omitempty"`               // "purpose": "General",
+	SmartLink             bool            `json:"smartLink"`                       // "smartLink": false,
+	State                 string          `json:"state,omitempty"`                 // "state": "Normal",
+	Status                string          `json:"status,omitempty"`                // "status": "Critical",
+	Type                  string          `json:"type,omitempty"`                  // "type": "ethernet-networkV3",
+	URI                   utils.Nstring   `json:"uri,omitempty"`                   // "uri": "/rest/ethernet-networks/e2f0031b-52bd-4223-9ac1-d91cb519d548"
+	VlanId                int             `json:"vlanId,omitempty"`                // "vlanId": 1,
+	ScopesUri             utils.Nstring   `json:"scopesUri,omitempty"`             // "scopesUri":
+	InitialScopeUris      []utils.Nstring `json:"initialScopeUris,omitempty"`      // "initialScopUris":
 }
 
 type EthernetNetworkList struct {
@@ -34,15 +36,30 @@ type EthernetNetworkList struct {
 	Start       int               `json:"start,omitempty"`       // "start": 0,
 	PrevPageURI utils.Nstring     `json:"prevPageUri,omitempty"` // "prevPageUri": null,
 	NextPageURI utils.Nstring     `json:"nextPageUri,omitempty"` // "nextPageUri": null,
-	URI         utils.Nstring     `json:"uri,omitempty"`         // "uri": "/rest/server-profiles?filter=connectionTemplateUri%20matches%7769cae0-b680-435b-9b87-9b864c81657fsort=name:asc"
+	URI         utils.Nstring     `json:"uri,omitempty"`         // "uri": "/rest/ethernet-networks?filter=connectionTemplateUri%20matches%7769cae0-b680-435b-9b87-9b864c81657fsort=name:asc"
 	Members     []EthernetNetwork `json:"members,omitempty"`     // "members":[]
+}
+
+type Bandwidth struct {
+	MaximumBandwidth int `json:"maximumBandwidth"` //"maximumBandwidth":10000
+	TypicalBandwidth int `json:"typicalBandwidth"` //"typicalBandwidth":2000
+}
+
+type BulkEthernetNetwork struct {
+	VlanIdRange    string    `json:"vlanIdRange"`    // "vlanIdRange":"1-500",
+	Purpose        string    `json:"purpose"`        // "purpose":"General",
+	NamePrefix     string    `json:"namePrefix"`     // "namePrefix":"TestNetwork",
+	SmartLink      bool      `json:"smartLink"`      // "smartLink":false,
+	PrivateNetwork bool      `json:"privateNetwork"` // "privateNetwork":false,
+	Bandwidth      Bandwidth `json:"bandwidth"`      // "bandwidth":10000,2000
+	Type           string    `json:"type"`           // "type":"bulk-ethernet-network",
 }
 
 func (c *OVClient) GetEthernetNetworkByName(name string) (EthernetNetwork, error) {
 	var (
 		eNet EthernetNetwork
 	)
-	eNets, err := c.GetEthernetNetworks(fmt.Sprintf("name matches '%s'", name), "name:asc")
+	eNets, err := c.GetEthernetNetworks("", "", fmt.Sprintf("name matches '%s'", name), "name:asc")
 	if eNets.Total > 0 {
 		return eNets.Members[0], err
 	} else {
@@ -50,7 +67,7 @@ func (c *OVClient) GetEthernetNetworkByName(name string) (EthernetNetwork, error
 	}
 }
 
-func (c *OVClient) GetEthernetNetworks(filter string, sort string) (EthernetNetworkList, error) {
+func (c *OVClient) GetEthernetNetworks(start string, count string, filter string, sort string) (EthernetNetworkList, error) {
 	var (
 		uri              = "/rest/ethernet-networks"
 		q                map[string]interface{}
@@ -63,6 +80,14 @@ func (c *OVClient) GetEthernetNetworks(filter string, sort string) (EthernetNetw
 
 	if sort != "" {
 		q["sort"] = sort
+	}
+
+	if start != "" {
+		q["start"] = start
+	}
+
+	if count != "" {
+		q["count"] = count
 	}
 
 	// refresh login
@@ -83,6 +108,46 @@ func (c *OVClient) GetEthernetNetworks(filter string, sort string) (EthernetNetw
 		return ethernetNetworks, err
 	}
 	return ethernetNetworks, nil
+}
+
+func (c *OVClient) GetAssociatedProfile(id string) ([]string, error) {
+	var (
+		uri            = "/rest/ethernet-networks/"
+		serverProfiles = new([]string)
+	)
+	uri = uri + id + "/associatedProfiles"
+	// refresh login
+	c.RefreshLogin()
+	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
+	data, err := c.RestAPICall(rest.GET, uri, nil)
+	if err != nil {
+		return *serverProfiles, err
+	}
+	log.Infof("GetAssociatedProfile %s", data)
+	if err := json.Unmarshal([]byte(data), serverProfiles); err != nil {
+		return *serverProfiles, err
+	}
+	return *serverProfiles, nil
+}
+
+func (c *OVClient) GetAssociatedUplinkGroup(id string) ([]string, error) {
+	var (
+		uri          = "/rest/ethernet-networks/"
+		uplinkGroups = new([]string)
+	)
+	uri = uri + id + "/associatedUplinkGroups"
+	// refresh login
+	c.RefreshLogin()
+	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
+	data, err := c.RestAPICall(rest.GET, uri, nil)
+	if err != nil {
+		return *uplinkGroups, err
+	}
+	log.Infof("GetAssociatedUplinkGroups %s", data)
+	if err := json.Unmarshal([]byte(data), uplinkGroups); err != nil {
+		return *uplinkGroups, err
+	}
+	return *uplinkGroups, nil
 }
 
 func (c *OVClient) CreateEthernetNetwork(eNet EthernetNetwork) error {
@@ -118,6 +183,40 @@ func (c *OVClient) CreateEthernetNetwork(eNet EthernetNetwork) error {
 		return err
 	}
 
+	return nil
+}
+
+func (c *OVClient) CreateBulkEthernetNetwork(eNet BulkEthernetNetwork) error {
+	log.Infof("Initializing creation of bulk ethernet network")
+	var (
+		uri = "rest/ethernet-networks/bulk"
+		t   *Task
+	)
+	//refresh login
+	c.RefreshLogin()
+	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
+	t = t.NewProfileTask(c)
+	t.ResetTask()
+	log.Debugf("REST :%s \n %+v\n", uri, eNet)
+	log.Debugf("task -> %+v", t)
+	data, err := c.RestAPICall(rest.POST, uri, eNet)
+	if err != nil {
+		t.TaskIsDone = true
+		log.Errorf("Error submitting new bulk ethernet network request: %s", err)
+		return err
+	}
+
+	log.Debugf("Response New Bulk EthernetNetwork %s", data)
+	if err := json.Unmarshal([]byte(data), &t); err != nil {
+		t.TaskIsDone = true
+		log.Errorf("Error with task un-marshal: %s", err)
+		return err
+	}
+
+	err = t.Wait()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/vendor/github.com/HewlettPackard/oneview-golang/ov/logical_interconnect_group.go
+++ b/vendor/github.com/HewlettPackard/oneview-golang/ov/logical_interconnect_group.go
@@ -32,7 +32,7 @@ type LogicalInterconnectGroup struct {
 	Status                  string                   `json:"status,omitempty"`                 // "status": "Critical",
 	TelemetryConfiguration  *TelemetryConfiguration  `json:"telemetryConfiguration,omitempty"` // "telemetryConfiguration": {...},
 	Type                    string                   `json:"type"`                             // "type": "logical-interconnect-groupsV3",
-	UplinkSets              []UplinkSet              `json:"uplinkSets,omitempty"`             // "uplinkSets": {...},
+	UplinkSets              []UplinkSets             `json:"uplinkSets,omitempty"`             // "uplinkSets": {...},
 	URI                     utils.Nstring            `json:"uri,omitempty"`                    // "uri": "/rest/logical-interconnect-groups/e2f0031b-52bd-4223-9ac1-d91cb519d548",
 }
 
@@ -181,7 +181,8 @@ type SnmpConfiguration struct {
 	SystemContact    string            `json:"systemContact,omitempty"`    // "systemContact": "",
 	TrapDestinations []TrapDestination `json:"trapDestinations,omitempty"` // "trapDestinations": {...}
 	Type             string            `json:"type,omitempty"`             // "type": "snmp-configuration",
-	URI              utils.Nstring     `json:"uri,omitempty"`              // "uri": null
+	URI              utils.Nstring     `json:"uri,omitempty"`              // "uri": null,
+	V3Enabled        *bool             `json:"v3Enabled,omitempty"`        // "v3Enabled": true
 }
 
 type TrapDestination struct {
@@ -210,7 +211,7 @@ type TelemetryConfiguration struct {
 	URI             utils.Nstring `json:"uri,omitempty"`             // "uri": null
 }
 
-type UplinkSet struct {
+type UplinkSets struct {
 	EthernetNetworkType    string                  `json:"ethernetNetworkType,omitempty"` // "ethernetNetworkType": "Tagged",
 	LacpTimer              string                  `json:"lacpTimer,omitempty"`           // "lacpTimer": "Long",
 	LogicalPortConfigInfos []LogicalPortConfigInfo `json:"logicalPortConfigInfos"`        // "logicalPortConfigInfos": {...},

--- a/vendor/github.com/HewlettPackard/oneview-golang/ov/storage_pool.go
+++ b/vendor/github.com/HewlettPackard/oneview-golang/ov/storage_pool.go
@@ -1,0 +1,131 @@
+package ov
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/HewlettPackard/oneview-golang/rest"
+	"github.com/HewlettPackard/oneview-golang/utils"
+	"github.com/docker/machine/libmachine/log"
+)
+
+// The Marshal() will omit the bool attibutes below if they are false.
+// Please remove the omitempty option and use it as and when required.
+
+type StoragePoolV3 struct {
+	Category                 string                    `json:"category,omitempty"`
+	Created                  string                    `json:"created,omitempty"`
+	Description              string                    `json:"description,omitempty"`
+	ETAG                     string                    `json:"eTag,omitempty"`
+	Name                     string                    `json:"name,omitempty"`
+	State                    string                    `json:"state,omitempty"`
+	Status                   string                    `json:"status,omitempty"`
+	Type                     string                    `json:"type,omitempty"`
+	URI                      utils.Nstring             `json:"uri,omitempty"`
+	AllocatedCapacity        string                    `json:"allocatedCapacity,omitempty"`
+	InitialScopeUris         utils.Nstring             `json:"initialScopeUris,omitempty"`
+	DeviceSpecificAttributes *DeviceSpecificAttributes `json:"deviceSpecificAttributes,omitempty"`
+	StorageSystemUri         utils.Nstring             `json:"storageSystemUri,omitempty"`
+	TotalCapacity            string                    `json:"totalCapacity,omitempty"`
+	FreeCapacity             string                    `json:"freeCapacity,omitempty"`
+	IsManaged                bool                      `json:"isManaged"`
+}
+
+type StoragePoolsListV3 struct {
+	Total       int             `json:"total,omitempty"`       // "total": 1,
+	Count       int             `json:"count,omitempty"`       // "count": 1,
+	Start       int             `json:"start,omitempty"`       // "start": 0,
+	PrevPageURI utils.Nstring   `json:"prevPageUri,omitempty"` // "prevPageUri": null,
+	NextPageURI utils.Nstring   `json:"nextPageUri,omitempty"` // "nextPageUri": null,
+	URI         utils.Nstring   `json:"uri,omitempty"`         // "uri": "/rest/storage-pools?filter=connectionTemplateUri%20matches%7769cae0-b680-435b-9b87-9b864c81657fsort=name:asc"
+	Members     []StoragePoolV3 `json:"members,omitempty"`     // "members":[]
+}
+
+func (c *OVClient) GetStoragePoolByName(name string) (StoragePoolV3, error) {
+	var (
+		sPool StoragePoolV3
+	)
+	sPools, err := c.GetStoragePools(fmt.Sprintf("name matches '%s'", name), "name:asc", "", "")
+	if sPools.Total > 0 {
+		return sPools.Members[0], err
+	} else {
+		return sPool, err
+	}
+}
+
+func (c *OVClient) GetStoragePools(filter string, sort string, start string, count string) (StoragePoolsListV3, error) {
+	var (
+		uri    = "/rest/storage-pools"
+		q      map[string]interface{}
+		sPools StoragePoolsListV3
+	)
+	q = make(map[string]interface{})
+	if len(filter) > 0 {
+		q["filter"] = filter
+	}
+
+	if sort != "" {
+		q["sort"] = sort
+	}
+
+	if start != "" {
+		q["start"] = start
+	}
+
+	if count != "" {
+		q["count"] = count
+	}
+
+	// refresh login
+	c.RefreshLogin()
+	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
+	// Setup query
+	if len(q) > 0 {
+		c.SetQueryString(q)
+	}
+
+	data, err := c.RestAPICall(rest.GET, uri, nil)
+	if err != nil {
+		return sPools, err
+	}
+
+	log.Debugf("GetStoragePools %s", data)
+	if err := json.Unmarshal([]byte(data), &sPools); err != nil {
+		return sPools, err
+	}
+	return sPools, nil
+}
+
+func (c *OVClient) UpdateStoragePool(sPool StoragePoolV3) error {
+	log.Infof("Initializing update of storage volume for %s.", sPool.Name)
+	var (
+		uri = sPool.URI.String()
+		t   *Task
+	)
+	// refresh login
+	c.RefreshLogin()
+	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
+
+	t = t.NewProfileTask(c)
+	t.ResetTask()
+	log.Debugf("REST : %s \n %+v\n", uri, sPool)
+	log.Debugf("task -> %+v", t)
+	data, err := c.RestAPICall(rest.PUT, uri, sPool)
+	if err != nil {
+		t.TaskIsDone = true
+		log.Errorf("Error submitting update StoragePool request: %s", err)
+		return err
+	}
+	log.Debugf("Response update StoragePool %s", data)
+	if err := json.Unmarshal([]byte(data), &t); err != nil {
+		t.TaskIsDone = true
+		log.Errorf("Error with task un-marshal: %s", err)
+		return err
+	}
+
+	err = t.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/HewlettPackard/oneview-golang/ov/storage_system.go
+++ b/vendor/github.com/HewlettPackard/oneview-golang/ov/storage_system.go
@@ -1,0 +1,286 @@
+/*
+(c) Copyright [2018] Hewlett Packard Enterprise Development LP
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ov
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/HewlettPackard/oneview-golang/rest"
+	"github.com/HewlettPackard/oneview-golang/utils"
+	"github.com/docker/machine/libmachine/log"
+)
+
+type StorageSystemV4 struct {
+	Hostname                              string                                 `json:"hostname,omitempty"`
+	Username                              string                                 `json:"username,omitempty"`
+	Password                              string                                 `json:"password,omitempty"`
+	Credentials                           *Credentials                           `json:"credentials,omitempty"`
+	Category                              string                                 `json:"category,omitempty"`
+	ETAG                                  string                                 `json:"eTag,omitempty"`
+	Name                                  string                                 `json:"name,omitempty"`
+	Description                           string                                 `json:"description,omitempty"`
+	State                                 string                                 `json:"state,omitempty"`
+	Status                                string                                 `json:"status,omitempty"`
+	Type                                  string                                 `json:"type,omitempty"`
+	URI                                   utils.Nstring                          `json:"uri,omitempty"`
+	Family                                string                                 `json:"family,omitempty"`
+	StoragePoolsUri                       utils.Nstring                          `json:"storagePoolsUri,omitempty"`
+	TotalCapacity                         string                                 `json:"totalCapacity,omitempty"`
+	Mode                                  string                                 `json:"mode,omitempty"`
+	Ports                                 []Ports                                `json:"ports,omitempty"`
+	StorageSystemDeviceSpecificAttributes *StorageSystemDeviceSpecificAttributes `json:"deviceSpecificAttributes,omitempty"`
+}
+
+type Credentials struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+type Ports struct {
+	PortDeviceSpecificAttributes PortDeviceSpecificAttributes `json:"deviceSpecificAttributes,omitempty"`
+	Id                           string                       `json:"id,omitempty"`
+	Mode                         string                       `json:"mode,omitempty"`
+}
+
+type PortDeviceSpecificAttributes struct {
+	PartnerPort string `json:"partnerport,omitempty"`
+}
+
+type StorageSystemDeviceSpecificAttributes struct {
+	Firmware      string         `json:"firmware,omitempty"`
+	Model         string         `json:"model,omitempty"`
+	ManagedPools  []ManagedPools `json:"managedPools,omitempty"`
+	ManagedDomain string         `json:"managedDomain,omitempty"`
+}
+
+type ManagedPools struct {
+	Name          string `json:"name,omitempty"`
+	Domain        string `json:"domain,omitempty"`
+	DeviceType    string `json:"deviceType,omitempty"`
+	FreeCapacity  string `json:"freeCapacity,omitempty"`
+	RaidLevel     string `json:"raidLevel,omitempty"`
+	Totalcapacity string `json:"totalCapacity,omitempty"`
+}
+
+type StorageSystemsListV4 struct {
+	Total       int               `json:"total,omitempty"`       // "total": 1,
+	Count       int               `json:"count,omitempty"`       // "count": 1,
+	Start       int               `json:"start,omitempty"`       // "start": 0,
+	PrevPageURI utils.Nstring     `json:"prevPageUri,omitempty"` // "prevPageUri": null,
+	NextPageURI utils.Nstring     `json:"nextPageUri,omitempty"` // "nextPageUri": null,
+	URI         utils.Nstring     `json:"uri,omitempty"`         // "uri": "/rest/storage-systems"
+	Members     []StorageSystemV4 `json:"members,omitempty"`     // "members":[]
+}
+
+type ReachablePortsList struct {
+	Category    string           `json:"category,omitempty"`
+	Members     []ReachablePorts `json:"members,omitempty"`
+	Total       int              `json:"total,omitempty"`
+	Count       int              `json:"count,omitempty"`
+	Start       int              `json:"start,omitempty"`
+	PrevPageURI utils.Nstring    `json:"prevPageUri,omitempty"`
+	NextPageURI utils.Nstring    `json:"nextPageUri,omitempty"`
+	URI         utils.Nstring    `json:"uri,omitempty"`
+}
+
+type ReachablePorts struct {
+	ReachableNetworks utils.Nstring `json:"reachableNetworks,omitempty"`
+}
+
+func (c *OVClient) GetStorageSystemByName(name string) (StorageSystemV4, error) {
+	var (
+		sSystem StorageSystemV4
+	)
+	sSystems, err := c.GetStorageSystems(fmt.Sprintf("name matches '%s'", name), "name:asc")
+	if sSystems.Total > 0 {
+		return sSystems.Members[0], err
+	} else {
+		return sSystem, err
+	}
+}
+
+func (c *OVClient) GetStorageSystems(filter string, sort string) (StorageSystemsListV4, error) {
+	var (
+		uri     = "/rest/storage-systems"
+		q       map[string]interface{}
+		sSystem StorageSystemsListV4
+	)
+	q = make(map[string]interface{})
+	if len(filter) > 0 {
+		q["filter"] = filter
+	}
+
+	if sort != "" {
+		q["sort"] = sort
+	}
+
+	// refresh login
+	c.RefreshLogin()
+	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
+	// Setup query
+	if len(q) > 0 {
+		c.SetQueryString(q)
+	}
+
+	data, err := c.RestAPICall(rest.GET, uri, nil)
+	if err != nil {
+		return sSystem, err
+	}
+
+	log.Debugf("GetStorageSystems %s", data)
+	if err := json.Unmarshal([]byte(data), &sSystem); err != nil {
+		return sSystem, err
+	}
+	return sSystem, nil
+}
+
+func (c *OVClient) CreateStorageSystem(sSystem StorageSystemV4) error {
+	log.Infof("Initializing creation of storage volume for %s.", sSystem.Name)
+	var (
+		uri = "/rest/storage-systems"
+		t   *Task
+	)
+	// refresh login
+	c.RefreshLogin()
+	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
+
+	t = t.NewProfileTask(c)
+	t.ResetTask()
+	log.Debugf("REST : %s \n %+v\n", uri, sSystem)
+	log.Debugf("task -> %+v", t)
+
+	data, err := c.RestAPICall(rest.POST, uri, sSystem)
+	if err != nil {
+		t.TaskIsDone = true
+		log.Errorf("Error submitting new storage volume request: %s", err)
+		return err
+	}
+
+	log.Debugf("Response New StorageSystem %s", data)
+	if err := json.Unmarshal([]byte(data), &t); err != nil {
+		t.TaskIsDone = true
+		log.Errorf("Error with task un-marshal: %s", err)
+		return err
+	}
+
+	err = t.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *OVClient) DeleteStorageSystem(name string) error {
+	var (
+		sSystem StorageSystemV4
+		err     error
+		t       *Task
+		uri     string
+	)
+
+	sSystem, err = c.GetStorageSystemByName(name)
+	if err != nil {
+		return err
+	}
+	if sSystem.Name != "" {
+		t = t.NewProfileTask(c)
+		t.ResetTask()
+		log.Debugf("REST : %s \n %+v\n", sSystem.URI, sSystem)
+		log.Debugf("task -> %+v", t)
+		uri = sSystem.URI.String()
+		if uri == "" {
+			log.Warn("Unable to post delete, no uri found.")
+			t.TaskIsDone = true
+			return err
+		}
+		data, err := c.RestAPICall(rest.DELETE, uri, nil)
+		if err != nil {
+			log.Errorf("Error submitting delete storage volume request: %s", err)
+			t.TaskIsDone = true
+			return err
+		}
+
+		log.Debugf("Response delete storage volume %s", data)
+		if err := json.Unmarshal([]byte(data), &t); err != nil {
+			t.TaskIsDone = true
+			log.Errorf("Error with task un-marshal: %s", err)
+			return err
+		}
+		err = t.Wait()
+		if err != nil {
+			return err
+		}
+		return nil
+	} else {
+		log.Infof("StorageSystem could not be found to delete, %s, skipping delete ...", name)
+	}
+	return nil
+}
+
+func (c *OVClient) UpdateStorageSystem(sSystem StorageSystemV4) error {
+	log.Infof("Initializing update of storage volume for %s.", sSystem.Name)
+	var (
+		uri = sSystem.URI.String()
+		t   *Task
+	)
+	// refresh login
+	c.RefreshLogin()
+	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
+
+	t = t.NewProfileTask(c)
+	t.ResetTask()
+	log.Debugf("REST : %s \n %+v\n", uri, sSystem)
+	log.Debugf("task -> %+v", t)
+	data, err := c.RestAPICall(rest.PUT, uri, sSystem)
+	if err != nil {
+		t.TaskIsDone = true
+		log.Errorf("Error submitting update StorageSystem request: %s", err)
+		return err
+	}
+
+	log.Debugf("Response update StorageSystem %s", data)
+	if err := json.Unmarshal([]byte(data), &t); err != nil {
+		t.TaskIsDone = true
+		log.Errorf("Error with task un-marshal: %s", err)
+		return err
+	}
+
+	err = t.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *OVClient) GetReachablePorts(uri utils.Nstring) (ReachablePortsList, error) {
+	var (
+		reachable_ports ReachablePortsList
+		main_uri        = uri.String()
+	)
+	c.RefreshLogin()
+	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
+	main_uri = main_uri + "/reachable-ports"
+	data, err := c.RestAPICall(rest.GET, main_uri, nil)
+	if err != nil {
+		log.Errorf("Error in getting reachable ports: %s", err)
+		return reachable_ports, err
+	}
+	log.Debugf("Reachable ports %s", data)
+	if err := json.Unmarshal([]byte(data), &reachable_ports); err != nil {
+		return reachable_ports, err
+	}
+	return reachable_ports, nil
+}

--- a/vendor/github.com/HewlettPackard/oneview-golang/ov/storage_volume_attachment.go
+++ b/vendor/github.com/HewlettPackard/oneview-golang/ov/storage_volume_attachment.go
@@ -1,0 +1,122 @@
+package ov
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/HewlettPackard/oneview-golang/rest"
+	"github.com/HewlettPackard/oneview-golang/utils"
+	"github.com/docker/machine/libmachine/log"
+)
+
+// The Marshal() will omit the bool attibutes below if they are false.
+// Please remove the omitempty option and use it as and when required.
+
+type StorageAttachment struct {
+	Category         string        `json:"category,omitempty"`
+	Created          string        `json:"created,omitempty"`
+	Description      string        `json:"description,omitempty"`
+	ETAG             string        `json:"eTag,omitempty"`
+	Host             *Host         `json:"host,omitempty"`
+	Paths            *Paths        `json:"paths,omitempty"`
+	Name             string        `json:"name,omitempty"`
+	State            string        `json:"state,omitempty"`
+	Status           string        `json:"status,omitempty"`
+	Type             string        `json:"type,omitempty"`
+	URI              utils.Nstring `json:"uri,omitempty"`
+	StorageSystemUri utils.Nstring `json:"storageSystemUri,omitempty"`
+	StorageVolumeUri utils.Nstring `json:"storageVolumeUri,omitempty"`
+}
+
+type Host struct {
+	Name string `json:"name,omitempty"`
+	Os   string `json:"os,omitempty"`
+}
+
+type Paths struct {
+	ConnectionName     string     `json:"connectionName,omitempty"`
+	ExpectedNetworkUri string     `json:"expectedNetworkUri,omitempty"`
+	Initiator          *Initiator `json:"initiator,omitempty"`
+	IsEnabled          bool       `json:"isEnabled,omitempty"`
+	Transport          string     `json:"transport,omitempty"`
+}
+
+type Initiator struct {
+	Chap       *Chap       `json:"chap,omitempty"`
+	MutualChap *MutualChap `json:"mutualChap,omitempty"`
+	Name       string      `json:"name,omitempty"`
+}
+
+type Chap struct {
+	Name   string `json:"name,omitempty"`
+	secret string `json:"secret,omitempty"`
+}
+
+type MutualChap struct {
+	Name   string `json:"name,omitempty"`
+	secret string `json:"secret,omitempty"`
+}
+
+type StorageAttachmentsListV2 struct {
+	Total       int                 `json:"total,omitempty"`       // "total": 1,
+	Count       int                 `json:"count,omitempty"`       // "count": 1,
+	Start       int                 `json:"start,omitempty"`       // "start": 0,
+	PrevPageURI utils.Nstring       `json:"prevPageUri,omitempty"` // "prevPageUri": null,
+	NextPageURI utils.Nstring       `json:"nextPageUri,omitempty"` // "nextPageUri": null,
+	URI         utils.Nstring       `json:"uri,omitempty"`         // "uri": "/rest/storage-pools?filter=connectionTemplateUri%20matches%7769cae0-b680-435b-9b87-9b864c81657fsort=name:asc"
+	Members     []StorageAttachment `json:"members,omitempty"`     // "members":[]
+}
+
+func (c *OVClient) GetStorageAttachmentByName(name string) (StorageAttachment, error) {
+	var (
+		sAttachment StorageAttachment
+	)
+	sAttachments, err := c.GetStorageAttachments(fmt.Sprintf("name matches '%s'", name), "name:asc", "", "")
+	if sAttachments.Total > 0 {
+		return sAttachments.Members[0], err
+	} else {
+		return sAttachment, err
+	}
+}
+
+func (c *OVClient) GetStorageAttachments(filter string, sort string, start string, count string) (StorageAttachmentsListV2, error) {
+	var (
+		uri          = "/rest/storage-volume-attachments"
+		q            map[string]interface{}
+		sAttachments StorageAttachmentsListV2
+	)
+	q = make(map[string]interface{})
+	if len(filter) > 0 {
+		q["filter"] = filter
+	}
+
+	if sort != "" {
+		q["sort"] = sort
+	}
+
+	if start != "" {
+		q["start"] = start
+	}
+
+	if count != "" {
+		q["count"] = count
+	}
+
+	// refresh login
+	c.RefreshLogin()
+	c.SetAuthHeaderOptions(c.GetAuthHeaderMap())
+	// Setup query
+	if len(q) > 0 {
+		c.SetQueryString(q)
+	}
+
+	data, err := c.RestAPICall(rest.GET, uri, nil)
+	if err != nil {
+		return sAttachments, err
+	}
+
+	log.Debugf("GetStorageAttachments %s", data)
+	if err := json.Unmarshal([]byte(data), &sAttachments); err != nil {
+		return sAttachments, err
+	}
+	return sAttachments, nil
+}

--- a/vendor/github.com/HewlettPackard/oneview-golang/rest/netutil.go
+++ b/vendor/github.com/HewlettPackard/oneview-golang/rest/netutil.go
@@ -176,11 +176,12 @@ func (c *Client) RestAPICall(method Method, path string, options interface{}) ([
 	data, err := ioutil.ReadAll(resp.Body)
 	if !c.isOkStatus(resp.StatusCode) {
 		type apiErr struct {
-			Err string `json:"details"`
+			Message string `json:"message"`
+			Details string `json:"details"`
 		}
 		var outErr apiErr
 		json.Unmarshal(data, &outErr)
-		return nil, fmt.Errorf("Error in response: %s\n Response Status: %s", outErr.Err, resp.Status)
+		return nil, fmt.Errorf("Error in response: %s\n Response Status: %s\n Response Details: %s", outErr.Message, resp.Status, outErr.Details)
 	}
 
 	if err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -85,38 +85,38 @@
 		{
 			"checksumSHA1": "kasshieWdVIntOY0Vrz1OXNv7IA=",
 			"path": "github.com/HewlettPackard/oneview-golang/i3s",
-			"revision": "e12ba8ba9b2ae861a36b397c1518b3a2ea8f9ae3",
-			"revisionTime": "2018-12-14T09:34:54Z"
+			"revision": "4e7a40fe7e77cf0ebc9941c6f10e583aba873901",
+			"revisionTime": "2019-01-21T09:07:18Z"
 		},
 		{
 			"checksumSHA1": "yrIv4kgbuYsHS05EqD5Va+sATQM=",
 			"path": "github.com/HewlettPackard/oneview-golang/icsp",
-			"revision": "e12ba8ba9b2ae861a36b397c1518b3a2ea8f9ae3",
-			"revisionTime": "2018-12-14T09:34:54Z"
+			"revision": "4e7a40fe7e77cf0ebc9941c6f10e583aba873901",
+			"revisionTime": "2019-01-21T09:07:18Z"
 		},
 		{
 			"checksumSHA1": "T7C6uoGuuhXZ0UNMJr/7IyhF5ls=",
 			"path": "github.com/HewlettPackard/oneview-golang/liboneview",
-			"revision": "e12ba8ba9b2ae861a36b397c1518b3a2ea8f9ae3",
-			"revisionTime": "2018-12-14T09:34:54Z"
+			"revision": "4e7a40fe7e77cf0ebc9941c6f10e583aba873901",
+			"revisionTime": "2019-01-21T09:07:18Z"
 		},
 		{
-			"checksumSHA1": "xu3yFPcC2TgAOdI7UgQtC3A1UZ4=",
+			"checksumSHA1": "+1nnO0GGTcj86EBQMsy28EHMXpw=",
 			"path": "github.com/HewlettPackard/oneview-golang/ov",
-			"revision": "e12ba8ba9b2ae861a36b397c1518b3a2ea8f9ae3",
-			"revisionTime": "2018-12-14T09:34:54Z"
+			"revision": "4e7a40fe7e77cf0ebc9941c6f10e583aba873901",
+			"revisionTime": "2019-01-21T09:07:18Z"
 		},
 		{
-			"checksumSHA1": "7Q3w9aVaZp71xhvjFFWUhRgkqT0=",
+			"checksumSHA1": "FvTuPZUjQi9nSxEqpSBnLJePgqY=",
 			"path": "github.com/HewlettPackard/oneview-golang/rest",
-			"revision": "e12ba8ba9b2ae861a36b397c1518b3a2ea8f9ae3",
-			"revisionTime": "2018-12-14T09:34:54Z"
+			"revision": "4e7a40fe7e77cf0ebc9941c6f10e583aba873901",
+			"revisionTime": "2019-01-21T09:07:18Z"
 		},
 		{
 			"checksumSHA1": "tSDhcm+zX/nRBHeXiQN2KqaRKu0=",
 			"path": "github.com/HewlettPackard/oneview-golang/utils",
-			"revision": "e12ba8ba9b2ae861a36b397c1518b3a2ea8f9ae3",
-			"revisionTime": "2018-12-14T09:34:54Z"
+			"revision": "4e7a40fe7e77cf0ebc9941c6f10e583aba873901",
+			"revisionTime": "2019-01-21T09:07:18Z"
 		},
 		{
 			"path": "github.com/Unknwon/com",


### PR DESCRIPTION
This adds a `v3_enabled` option to SNMP Configuration for Logical Interconnect Groups in addition to the existing support for v1/v2.  Additionally fixes up the code for some recent changes made in oneview-golang.