### PR TITLE
Adding hardware power-on functionality to SP

### DIFF
--- a/examples/demos/infrastructure_provisioning_with_i3s.tf
+++ b/examples/demos/infrastructure_provisioning_with_i3s.tf
@@ -234,6 +234,7 @@ resource "oneview_server_profile" "SP" {
 	hardware_name = "SYN03_Frame1, bay 3"
 	type = "ServerProfileV10"
 	template = "${oneview_server_profile_template.ServerProfileTemplate.name}"
+	power_state = "on"
 	os_deployment_settings = {
 		os_custom_attributes = [{
 			name="HostName"

--- a/oneview/resource_server_profile.go
+++ b/oneview/resource_server_profile.go
@@ -82,6 +82,17 @@ func resourceServerProfile() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"power_state": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (warning []string, errors []error) {
+					val := v.(string)
+					if val != "on" && val != "off" {
+						errors = append(errors, fmt.Errorf("%q must be 'on' or 'off'", k))
+					}
+					return
+				},
+			},
 			"os_deployment_settings": {
 				Optional: true,
 				Type:     schema.TypeSet,
@@ -131,8 +142,10 @@ func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error
 	serverProfile.Type = d.Get("type").(string)
 	serverProfile.Name = d.Get("name").(string)
 
+	var serverHardware ov.ServerHardware
 	if val, ok := d.GetOk("hardware_name"); ok {
-		serverHardware, err := config.ovClient.GetServerHardwareByName(val.(string))
+		var err error
+		serverHardware, err = config.ovClient.GetServerHardwareByName(val.(string))
 		if err != nil {
 			return err
 		}
@@ -140,6 +153,12 @@ func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error
 			return errors.New("Server Hardware must be powered off to assign to the server profile")
 		}
 		serverProfile.ServerHardwareURI = serverHardware.URI
+	}
+
+	if d.Get("power_state").(string) == "on" {
+		if err := serverHardware.PowerOn(); err != nil {
+			return err
+		}
 	}
 
 	if val, ok := d.GetOk("os_deployment_settings"); ok {

--- a/oneview/resource_server_profile.go
+++ b/oneview/resource_server_profile.go
@@ -159,6 +159,10 @@ func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error
 		if err := serverHardware.PowerOn(); err != nil {
 			return err
 		}
+	} else if d.Get("power_state").(string) == "off" {
+		if err := serverHardware.PowerOff(); err != nil {
+			return err
+		}
 	}
 
 	if val, ok := d.GetOk("os_deployment_settings"); ok {

--- a/oneview/resource_server_profile.go
+++ b/oneview/resource_server_profile.go
@@ -155,16 +155,6 @@ func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error
 		serverProfile.ServerHardwareURI = serverHardware.URI
 	}
 
-	if d.Get("power_state").(string) == "on" {
-		if err := serverHardware.PowerOn(); err != nil {
-			return err
-		}
-	} else if d.Get("power_state").(string) == "off" {
-		if err := serverHardware.PowerOff(); err != nil {
-			return err
-		}
-	}
-
 	if val, ok := d.GetOk("os_deployment_settings"); ok {
 		rawOsDeploySetting := val.(*schema.Set).List()
 		for _, raw := range rawOsDeploySetting {
@@ -201,6 +191,10 @@ func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		d.SetId("")
 		return err
+	} else if d.Get("power_state").(string) == "on" {
+		if err := serverHardware.PowerOn(); err != nil {
+			return err
+		}
 	}
 
 	return resourceServerProfileRead(d, meta)
@@ -249,8 +243,10 @@ func resourceServerProfileUpdate(d *schema.ResourceData, meta interface{}) error
 		URI:  utils.NewNstring(d.Get("uri").(string)),
 	}
 
+	var serverHardware ov.ServerHardware
 	if val, ok := d.GetOk("hardware_name"); ok {
-		serverHardware, err := config.ovClient.GetServerHardwareByName(val.(string))
+		var err error
+		serverHardware, err = config.ovClient.GetServerHardwareByName(val.(string))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description
- Adds power_state attribute to server profile schema which can be used to power-on or off the server hardware.
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for go 1.11.x + gofmt checks .
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.