### PR TITLE
LIG Read Issue #285

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+# [v6.1.0-12] (Unreleased)
+
+### Bug fixes & Enhancements:
+- [#285] (https://github.com/HewlettPackard/terraform-provider-oneview/issues/285) Terraform crashes for Logical Interconnect Group Read. 
+
 # [v6.0.0-12]
 ### Notes
 - This release supports API2600 minimally where we can use OneView v6.00 with this SDK. 

--- a/data_source.tf
+++ b/data_source.tf
@@ -1,0 +1,23 @@
+provider "oneview" {
+  ov_username   = var.username
+  ov_password   = var.password
+  ov_endpoint   = var.endpoint
+  ov_sslverify  = var.ssl_enabled
+  ov_apiversion = 2600
+  ov_ifmatch    = "*"
+}
+
+# Test for data source  
+/*
+data "oneview_logical_interconnect_group" "logical_interconnect_group" {
+  name = "TestLIG5"
+}
+
+output "lig_value" {
+  value = data.oneview_logical_interconnect_group.logical_interconnect_group.redundancy_type
+}
+*/
+# Importing an existing resource from appliance
+resource "oneview_logical_interconnect_group" "import_lig" {
+}
+

--- a/oneview/resource_logical_interconnect_group.go
+++ b/oneview/resource_logical_interconnect_group.go
@@ -19,6 +19,9 @@ import (
 	"github.com/HewlettPackard/oneview-golang/ov"
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"encoding/json"
+	"io/ioutil"
 )
 
 func resourceLogicalInterconnectGroup() *schema.Resource {
@@ -711,7 +714,7 @@ func resourceLogicalInterconnectGroup() *schema.Resource {
 													},
 												},
 												"dscp_class_map": {
-													Type:     schema.TypeSet,
+													Type:     schema.TypeList,
 													Optional: true,
 													Elem:     &schema.Schema{Type: schema.TypeString},
 													Set:      schema.HashString,
@@ -1618,8 +1621,7 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 				"icm_name":        logicalInterconnectGroup.SflowConfiguration.SflowPorts[i].IcmName,
 				"port_name":       logicalInterconnectGroup.SflowConfiguration.SflowPorts[i].PortName,
 			})
-		}
-
+Set
 		sflowConfigurations := make([]map[string]interface{}, 0, 1)
 
 		sflowConfigurations = append(sflowConfigurations, map[string]interface{}{
@@ -1776,22 +1778,34 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 		d.Set("port_flap_settings", portFlapSettings)
 	}
 
+	file, _ := json.MarshalIndent(logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.QosTrafficClassifiers, "", " ")
+	_ = ioutil.WriteFile("test.json", file, 0644)
 	qosTrafficClasses := make([]map[string]interface{}, 0, 1)
 	for _, qosTrafficClass := range logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.QosTrafficClassifiers {
 
-		dscpClassMap := make([]interface{}, len(qosTrafficClass.QosClassificationMapping.DscpClassMapping))
-		for i, dscpValue := range qosTrafficClass.QosClassificationMapping.DscpClassMapping {
-			dscpClassMap[i] = dscpValue
+		dscpClassMap := make([]interface{}, 0)
+		if qosTrafficClass.QosClassificationMapping != nil{
+			for _, raw := range qosTrafficClass.QosClassificationMapping.DscpClassMapping {
+				dscpClassMap = append(dscpClassMap, raw)
+			}
+		}
+		dot1pClassMap := make([]interface{}, len(qosTrafficClass.QosClassificationMapping.Dot1pClassMapping))
+		if qosTrafficClass.QosClassificationMapping.Dot1pClassMapping != nil{
+			for i, dot1pValue := range qosTrafficClass.QosClassificationMapping.Dot1pClassMapping {
+				dot1pClassMap[i] = dot1pValue
+			}
 		}
 
-		dot1pClassMap := make([]interface{}, len(qosTrafficClass.QosClassificationMapping.Dot1pClassMapping))
-		for i, dot1pValue := range qosTrafficClass.QosClassificationMapping.Dot1pClassMapping {
-			dot1pClassMap[i] = dot1pValue
-		}
+		//dot1pClassMap := make([]interface{}, 0)
+		//if qosTrafficClass.QosClassificationMapping.Dot1pClassMapping != nil{
+		//	for _, raw := range qosTrafficClass.QosClassificationMapping.Dot1pClassMapping{
+		//		dot1pClassMap = append(dot1pClassMap, raw)
+		//	}
+		//}
 		qosClassificationMap := make([]map[string]interface{}, 0, 1)
 		qosClassificationMap = append(qosClassificationMap, map[string]interface{}{
 			"dot1p_class_map": schema.NewSet(func(a interface{}) int { return a.(int) }, dot1pClassMap),
-			"dscp_class_map":  schema.NewSet(schema.HashString, dscpClassMap),
+			"dscp_class_map":  dscpClassMap,
 		})
 
 		qosTrafficClasses = append(qosTrafficClasses, map[string]interface{}{
@@ -1804,6 +1818,8 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 			"qos_classification_map": qosClassificationMap,
 		})
 	}
+
+
 	qosTrafficClassCount := d.Get("quality_of_service.0.qos_traffic_class.#").(int)
 	oneviewTrafficClassCount := len(qosTrafficClasses)
 	for i := 0; i < qosTrafficClassCount; i++ {


### PR DESCRIPTION
### Description
TF Crashes for Read in LIG due to the bug in LIG Read method while collecting Qos attributes. 

### Issues Resolved
#285 

### Check List
- [x] New functionality includes testing.
  - [x]  All tests pass for go 1.11 + gofmt checks.
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.