### PR TITLE
LIG Read Issue for Terraform 0.11 #285

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -34,8 +34,13 @@ jobs:
         GOPATH: /home/runner/work/HewlettPackard/terraform-provider-oneview/go
 
     - name: Go formatting checks
-      run: if [ ! -z "$(find . -type f -name "*.go" -not -path "./vendor/*" | sed "s|^\./||" | xargs gofmt -l)" ]; then exit 1; fi
-    
+      run: if [ ! -z "$(find . -type f -name "*.go" -not -path "./vendor/*" | sed "s|^\./||" | xargs gofmt -l)" ]; then 
+            echo -e "Go files must be formatted with gofmt. Please run:";
+            for fn in $UNFORMATTED; do
+              echo -e "  gofmt -w $PWD/$fn";
+            done;
+           exit 1;
+           fi
     - name: Standard Go testing avoiding the testing of the vendor folder.
       run: |
         go vet $(go list ./... | grep -v '/vendor/')

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -39,8 +39,11 @@ jobs:
             for fn in $UNFORMATTED; do
               echo -e "  gofmt -w $PWD/$fn";
             done;
-           exit 1;
+            exit 1;
            fi
+      env: 
+        UNFORMATTED: $(find . -type f -name "*.go" -not -path "./vendor/*" | sed "s|^\./||" | xargs gofmt -l)
+
     - name: Standard Go testing avoiding the testing of the vendor folder.
       run: |
         go vet $(go list ./... | grep -v '/vendor/')

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -34,16 +34,11 @@ jobs:
         GOPATH: /home/runner/work/HewlettPackard/terraform-provider-oneview/go
 
     - name: Go formatting checks
-      run: if ! [ -z "$UNFORMATTED" ]; then 
-            echo -e "Go files must be formatted with gofmt. Please run:";
-            for fn in $UNFORMATTED; do
-              echo -e "  gofmt -w $PWD/$fn";
-            done;
-            exit 1;
-           fi
-      env: 
-        UNFORMATTED: $(find . -type f -name "*.go" -not -path "./vendor/*" | sed "s|^\./||" | xargs gofmt -l)
-
+      run: if ! [ -z "$(find . -type f -name "*.go" -not -path "./vendor/*" | sed "s|^\./||" | xargs gofmt -l)" ]; then 
+                    echo  -e " $(find . -type f -name "*.go" -not -path "./vendor/*" | sed "s|^\./||" | xargs gofmt -l)";
+            exit 1; 
+            fi
+    
     - name: Standard Go testing avoiding the testing of the vendor folder.
       run: |
         go vet $(go list ./... | grep -v '/vendor/')

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -34,7 +34,7 @@ jobs:
         GOPATH: /home/runner/work/HewlettPackard/terraform-provider-oneview/go
 
     - name: Go formatting checks
-      run: if ! [ -z "$(find . -type f -name "*.go" -not -path "./vendor/*" | sed "s|^\./||" | xargs gofmt -l)" ]; then 
+      run: if ! [ -z "$UNFORMATTED" ]; then 
             echo -e "Go files must be formatted with gofmt. Please run:";
             for fn in $UNFORMATTED; do
               echo -e "  gofmt -w $PWD/$fn";

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -34,7 +34,7 @@ jobs:
         GOPATH: /home/runner/work/HewlettPackard/terraform-provider-oneview/go
 
     - name: Go formatting checks
-      run: if [ ! -z "$(find . -type f -name "*.go" -not -path "./vendor/*" | sed "s|^\./||" | xargs gofmt -l)" ]; then 
+      run: if ! [ -z "$(find . -type f -name "*.go" -not -path "./vendor/*" | sed "s|^\./||" | xargs gofmt -l)" ]; then 
             echo -e "Go files must be formatted with gofmt. Please run:";
             for fn in $UNFORMATTED; do
               echo -e "  gofmt -w $PWD/$fn";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 All notable changes to this project will be documented in this file . 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+# [v6.1.0-11] (Unreleased)
+
+### Bug fixes & Enhancements:
+- [#285] (https://github.com/HewlettPackard/terraform-provider-oneview/issues/285) Terraform crashes for Logical Interconnect Group Read. 
+
 # [v6.0.0-11] 
 ### Notes
 - This release supports API2600 minimally where we can use OneView v6.00 with this SDK and Image Streamer API Version 2010.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-All notable changes to this project will be documented in this file . 
+All notable changes to this project will be documented in this file. 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 # [v6.1.0-11] (Unreleased)

--- a/oneview/data_source_interconnect_type.go
+++ b/oneview/data_source_interconnect_type.go
@@ -175,7 +175,7 @@ func dataSourceInterconnectTypeRead(d *schema.ResourceData, meta interface{}) er
 	DownlinkPortCapability = append(DownlinkPortCapability, map[string]interface{}{
 		"created":               interconnectType.DownlinkPortCapability.Created,
 		"max_bandwidth_in_gbps": interconnectType.DownlinkPortCapability.MaxBandwidthInGbps,
-		"uri": interconnectType.DownlinkPortCapability.URI,
+		"uri":                   interconnectType.DownlinkPortCapability.URI,
 	})
 	d.Set("downlink_port_capability", DownlinkPortCapability)
 

--- a/oneview/data_source_logical_interconnect_group.go
+++ b/oneview/data_source_logical_interconnect_group.go
@@ -1024,7 +1024,7 @@ func dataSourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interfa
 
 	interconnectSettings := make([]map[string]interface{}, 0, 1)
 	interconnectSetting := map[string]interface{}{
-		"type": logicalInterconnectGroup.EthernetSettings.Type,
+		"type":                    logicalInterconnectGroup.EthernetSettings.Type,
 		"fast_mac_cache_failover": *logicalInterconnectGroup.EthernetSettings.EnableFastMacCacheFailover,
 		"network_loop_protection": *logicalInterconnectGroup.EthernetSettings.EnableNetworkLoopProtection,
 		"pause_flood_protection":  *logicalInterconnectGroup.EthernetSettings.EnablePauseFloodProtection,
@@ -1038,16 +1038,16 @@ func dataSourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interfa
 	if logicalInterconnectGroup.IgmpSettings != nil {
 		igmpSettings := make([]map[string]interface{}, 0, 1)
 		igmpSetting := map[string]interface{}{
-			"category":               logicalInterconnectGroup.IgmpSettings.Category,
-			"consistency_checking":   logicalInterconnectGroup.IgmpSettings.ConsistencyChecking,
-			"created":                logicalInterconnectGroup.IgmpSettings.Created,
-			"dependent_resource_uri": logicalInterconnectGroup.IgmpSettings.DependentResourceUri,
-			"description":            logicalInterconnectGroup.IgmpSettings.Description,
-			"etag":                   logicalInterconnectGroup.IgmpSettings.ETAG,
-			"igmp_snooping":          *logicalInterconnectGroup.IgmpSettings.EnableIgmpSnooping,
-			"prevent_flooding":       *logicalInterconnectGroup.IgmpSettings.EnablePreventFlooding,
-			"proxy_reporting":        *logicalInterconnectGroup.IgmpSettings.EnableProxyReporting,
-			"id":                     logicalInterconnectGroup.IgmpSettings.ID,
+			"category":                   logicalInterconnectGroup.IgmpSettings.Category,
+			"consistency_checking":       logicalInterconnectGroup.IgmpSettings.ConsistencyChecking,
+			"created":                    logicalInterconnectGroup.IgmpSettings.Created,
+			"dependent_resource_uri":     logicalInterconnectGroup.IgmpSettings.DependentResourceUri,
+			"description":                logicalInterconnectGroup.IgmpSettings.Description,
+			"etag":                       logicalInterconnectGroup.IgmpSettings.ETAG,
+			"igmp_snooping":              *logicalInterconnectGroup.IgmpSettings.EnableIgmpSnooping,
+			"prevent_flooding":           *logicalInterconnectGroup.IgmpSettings.EnablePreventFlooding,
+			"proxy_reporting":            *logicalInterconnectGroup.IgmpSettings.EnableProxyReporting,
+			"id":                         logicalInterconnectGroup.IgmpSettings.ID,
 			"igmp_idle_timeout_interval": logicalInterconnectGroup.IgmpSettings.IgmpIdleTimeoutInterval,
 			"igmp_snooping_vlan_ids":     logicalInterconnectGroup.IgmpSettings.IgmpSnoopingVlanIds,
 			"modified":                   logicalInterconnectGroup.IgmpSettings.Modified,
@@ -1125,7 +1125,7 @@ func dataSourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interfa
 
 	qualityOfService := make([]map[string]interface{}, 0, 1)
 	qualityOfService = append(qualityOfService, map[string]interface{}{
-		"type": logicalInterconnectGroup.QosConfiguration.Type,
+		"type":                         logicalInterconnectGroup.QosConfiguration.Type,
 		"active_qos_config_type":       logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.Type,
 		"config_type":                  logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.ConfigType,
 		"uplink_classification_type":   logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.UplinkClassificationType,

--- a/oneview/data_source_server_profile.go
+++ b/oneview/data_source_server_profile.go
@@ -725,11 +725,11 @@ func dataSourceServerProfileRead(d *schema.ResourceData, meta interface{}) error
 	for _, controller := range serverProfile.LocalStorage.Controllers {
 
 		controllers = append(controllers, map[string]interface{}{
-			"device_slot":          controller.DeviceSlot,
-			"drive_write_cache":    controller.DriveWriteCache,
-			"import_configuration": controller.ImportConfiguration,
-			"initialize":           controller.Initialize,
-			"mode":                 controller.Mode,
+			"device_slot":              controller.DeviceSlot,
+			"drive_write_cache":        controller.DriveWriteCache,
+			"import_configuration":     controller.ImportConfiguration,
+			"initialize":               controller.Initialize,
+			"mode":                     controller.Mode,
 			"predictive_spare_rebuild": controller.PredictiveSpareRebuild,
 		})
 		logicaldrives := make([]map[string]interface{}, 0, len(controller.LogicalDrives))

--- a/oneview/data_source_server_profile_template.go
+++ b/oneview/data_source_server_profile_template.go
@@ -388,10 +388,10 @@ func dataSourceServerProfileTemplateRead(d *schema.ResourceData, meta interface{
 				})
 			}
 			controllers = append(controllers, map[string]interface{}{
-				"device_slot":       spt.LocalStorage.Controllers[i].DeviceSlot,
-				"initialize":        *spt.LocalStorage.Controllers[i].Initialize,
-				"drive_write_cache": spt.LocalStorage.Controllers[i].DriveWriteCache,
-				"mode":              spt.LocalStorage.Controllers[i].Mode,
+				"device_slot":              spt.LocalStorage.Controllers[i].DeviceSlot,
+				"initialize":               *spt.LocalStorage.Controllers[i].Initialize,
+				"drive_write_cache":        spt.LocalStorage.Controllers[i].DriveWriteCache,
+				"mode":                     spt.LocalStorage.Controllers[i].Mode,
 				"predictive_spare_rebuild": spt.LocalStorage.Controllers[i].PredictiveSpareRebuild,
 				"logical_drives":           logicalDrives,
 			})

--- a/oneview/data_source_storage_pool.go
+++ b/oneview/data_source_storage_pool.go
@@ -140,12 +140,12 @@ func dataSourceStoragePoolRead(d *schema.ResourceData, meta interface{}) error {
 	rawdevspecificattributes := storagePool.DeviceSpecificAttributes
 	devspecificattributes := make([]map[string]interface{}, 0)
 	devspecificattributes = append(devspecificattributes, map[string]interface{}{
-		"device_id":            rawdevspecificattributes.DeviceID,
-		"capacity_limit":       rawdevspecificattributes.CapacityLimit,
-		"device_speed":         rawdevspecificattributes.DeviceSpeed,
-		"domain":               rawdevspecificattributes.Domain,
-		"supported_raid_level": rawdevspecificattributes.SupportedRaidLevel,
-		"uuid":                 rawdevspecificattributes.Uuid,
+		"device_id":                rawdevspecificattributes.DeviceID,
+		"capacity_limit":           rawdevspecificattributes.CapacityLimit,
+		"device_speed":             rawdevspecificattributes.DeviceSpeed,
+		"domain":                   rawdevspecificattributes.Domain,
+		"supported_raid_level":     rawdevspecificattributes.SupportedRaidLevel,
+		"uuid":                     rawdevspecificattributes.Uuid,
 		"is_deduplication_capable": rawdevspecificattributes.IsDeduplicationCapable,
 	})
 	d.Set("storage_pool_device_specific_attributes", devspecificattributes)

--- a/oneview/resource_enclosure_group.go
+++ b/oneview/resource_enclosure_group.go
@@ -245,10 +245,10 @@ func resourceEnclosureGroupRead(d *schema.ResourceData, meta interface{}) error 
 func resourceEnclosureGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	enclosureGroup := ov.EnclosureGroup{
-		URI: utils.NewNstring(d.Get("uri").(string)),
+		URI:                         utils.NewNstring(d.Get("uri").(string)),
 		InterconnectBayMappingCount: d.Get("interconnect_bay_mapping_count").(int),
-		Type:         d.Get("type").(string),
-		StackingMode: d.Get("stacking_mode").(string),
+		Type:                        d.Get("type").(string),
+		StackingMode:                d.Get("stacking_mode").(string),
 	}
 
 	rawInterconnectBayMappings := d.Get("interconnect_bay_mappings").(*schema.Set).List()

--- a/oneview/resource_ethernet_network.go
+++ b/oneview/resource_ethernet_network.go
@@ -193,7 +193,7 @@ func resourceEthernetNetworkUpdate(d *schema.ResourceData, meta interface{}) err
 		PrivateNetwork:        d.Get("private_network").(bool),
 		SmartLink:             d.Get("smart_link").(bool),
 		ConnectionTemplateUri: utils.NewNstring(d.Get("connection_template_uri").(string)),
-		Type: d.Get("type").(string),
+		Type:                  d.Get("type").(string),
 	}
 
 	err := config.ovClient.UpdateEthernetNetwork(newENet)

--- a/oneview/resource_fc_network.go
+++ b/oneview/resource_fc_network.go
@@ -119,8 +119,8 @@ func resourceFCNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 		LinkStabilityTime:       d.Get("link_stability_time").(int),
 		ManagedSanURI:           utils.NewNstring(d.Get("managed_san_uri").(string)),
 		AutoLoginRedistribution: d.Get("auto_login_redistribution").(bool),
-		Type:        d.Get("type").(string),
-		Description: utils.NewNstring(d.Get("description").(string)),
+		Type:                    d.Get("type").(string),
+		Description:             utils.NewNstring(d.Get("description").(string)),
 	}
 
 	if val, ok := d.GetOk("initial_scope_uris"); ok {
@@ -179,9 +179,9 @@ func resourceFCNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
 		FabricType:              d.Get("fabric_type").(string),
 		LinkStabilityTime:       d.Get("link_stability_time").(int),
 		AutoLoginRedistribution: d.Get("auto_login_redistribution").(bool),
-		Type: d.Get("type").(string),
-		ConnectionTemplateUri: utils.NewNstring(d.Get("connection_template_uri").(string)),
-		Description:           utils.NewNstring(d.Get("description").(string)),
+		Type:                    d.Get("type").(string),
+		ConnectionTemplateUri:   utils.NewNstring(d.Get("connection_template_uri").(string)),
+		Description:             utils.NewNstring(d.Get("description").(string)),
 	}
 
 	err := config.ovClient.UpdateFcNetwork(fcNet)

--- a/oneview/resource_fcoe_network.go
+++ b/oneview/resource_fcoe_network.go
@@ -158,12 +158,12 @@ func resourceFCoENetworkUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	newFCoENet := ov.FCoENetwork{
-		ETAG:   d.Get("eTag").(string),
-		URI:    utils.NewNstring(d.Get("uri").(string)),
-		VlanId: d.Get("vlanId").(int),
-		Name:   d.Get("name").(string),
+		ETAG:                  d.Get("eTag").(string),
+		URI:                   utils.NewNstring(d.Get("uri").(string)),
+		VlanId:                d.Get("vlanId").(int),
+		Name:                  d.Get("name").(string),
 		ConnectionTemplateUri: utils.NewNstring(d.Get("connectionTemplateUri").(string)),
-		Type: d.Get("type").(string),
+		Type:                  d.Get("type").(string),
 	}
 
 	err := config.ovClient.UpdateFCoENetwork(newFCoENet)

--- a/oneview/resource_hypervisor_cluster_profile.go
+++ b/oneview/resource_hypervisor_cluster_profile.go
@@ -848,12 +848,12 @@ func resourceHypervisorClusterProfileUpdate(d *schema.ResourceData, meta interfa
 		HypervisorManagerUri:      utils.Nstring(d.Get("hypervisor_manager_uri").(string)),
 		HypervisorType:            d.Get("hypervisor_type").(string),
 		MgmtIpSettingsOverride:    d.Get("mgmt_ip_settings_override").(string),
-		Name:        d.Get("name").(string),
-		Path:        d.Get("path").(string),
-		ScopesUri:   d.Get("scopes_uri").(string),
-		StateReason: d.Get("state_reason").(string),
-		Type:        d.Get("type").(string),
-		URI:         utils.Nstring(d.Get("uri").(string)),
+		Name:                      d.Get("name").(string),
+		Path:                      d.Get("path").(string),
+		ScopesUri:                 d.Get("scopes_uri").(string),
+		StateReason:               d.Get("state_reason").(string),
+		Type:                      d.Get("type").(string),
+		URI:                       utils.Nstring(d.Get("uri").(string)),
 	}
 	hypClusterSettings := ov.HypervisorClusterSettings{}
 	HypervisorClusterSettingslist := d.Get("hypervisor_cluster_settings").(*schema.Set).List()

--- a/oneview/resource_logical_interconnect_group.go
+++ b/oneview/resource_logical_interconnect_group.go
@@ -13,11 +13,11 @@ package oneview
 
 import (
 	"fmt"
-	"reflect"
-	"strconv"
 	"github.com/HewlettPackard/oneview-golang/ov"
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/hashicorp/terraform/helper/schema"
+	"reflect"
+	"strconv"
 )
 
 func resourceLogicalInterconnectGroup() *schema.Resource {

--- a/oneview/resource_logical_interconnect_group.go
+++ b/oneview/resource_logical_interconnect_group.go
@@ -1713,7 +1713,7 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 
 	interconnectSettings := make([]map[string]interface{}, 0, 1)
 	interconnectSetting := map[string]interface{}{
-		"type": logicalInterconnectGroup.EthernetSettings.Type,
+		"type":                    logicalInterconnectGroup.EthernetSettings.Type,
 		"fast_mac_cache_failover": *logicalInterconnectGroup.EthernetSettings.EnableFastMacCacheFailover,
 		"network_loop_protection": *logicalInterconnectGroup.EthernetSettings.EnableNetworkLoopProtection,
 		"pause_flood_protection":  *logicalInterconnectGroup.EthernetSettings.EnablePauseFloodProtection,
@@ -1728,16 +1728,16 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 	if logicalInterconnectGroup.IgmpSettings != nil {
 		igmpSettings := make([]map[string]interface{}, 0, 1)
 		igmpSetting := map[string]interface{}{
-			"category":               logicalInterconnectGroup.IgmpSettings.Category,
-			"consistency_checking":   logicalInterconnectGroup.IgmpSettings.ConsistencyChecking,
-			"created":                logicalInterconnectGroup.IgmpSettings.Created,
-			"dependent_resource_uri": logicalInterconnectGroup.IgmpSettings.DependentResourceUri,
-			"description":            logicalInterconnectGroup.IgmpSettings.Description,
-			"etag":                   logicalInterconnectGroup.IgmpSettings.ETAG,
-			"igmp_snooping":          *logicalInterconnectGroup.IgmpSettings.EnableIgmpSnooping,
-			"prevent_flooding":       *logicalInterconnectGroup.IgmpSettings.EnablePreventFlooding,
-			"proxy_reporting":        *logicalInterconnectGroup.IgmpSettings.EnableProxyReporting,
-			"id":                     logicalInterconnectGroup.IgmpSettings.ID,
+			"category":                   logicalInterconnectGroup.IgmpSettings.Category,
+			"consistency_checking":       logicalInterconnectGroup.IgmpSettings.ConsistencyChecking,
+			"created":                    logicalInterconnectGroup.IgmpSettings.Created,
+			"dependent_resource_uri":     logicalInterconnectGroup.IgmpSettings.DependentResourceUri,
+			"description":                logicalInterconnectGroup.IgmpSettings.Description,
+			"etag":                       logicalInterconnectGroup.IgmpSettings.ETAG,
+			"igmp_snooping":              *logicalInterconnectGroup.IgmpSettings.EnableIgmpSnooping,
+			"prevent_flooding":           *logicalInterconnectGroup.IgmpSettings.EnablePreventFlooding,
+			"proxy_reporting":            *logicalInterconnectGroup.IgmpSettings.EnableProxyReporting,
+			"id":                         logicalInterconnectGroup.IgmpSettings.ID,
 			"igmp_idle_timeout_interval": logicalInterconnectGroup.IgmpSettings.IgmpIdleTimeoutInterval,
 			"igmp_snooping_vlan_ids":     logicalInterconnectGroup.IgmpSettings.IgmpSnoopingVlanIds,
 			"modified":                   logicalInterconnectGroup.IgmpSettings.Modified,
@@ -1820,7 +1820,7 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 
 	qualityOfService := make([]map[string]interface{}, 0, 1)
 	qualityOfService = append(qualityOfService, map[string]interface{}{
-		"type": logicalInterconnectGroup.QosConfiguration.Type,
+		"type":                         logicalInterconnectGroup.QosConfiguration.Type,
 		"active_qos_config_type":       logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.Type,
 		"config_type":                  logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.ConfigType,
 		"uplink_classification_type":   logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.UplinkClassificationType,

--- a/oneview/resource_logical_interconnect_group.go
+++ b/oneview/resource_logical_interconnect_group.go
@@ -13,11 +13,11 @@ package oneview
 
 import (
 	"fmt"
+	"reflect"
+	"strconv"
 	"github.com/HewlettPackard/oneview-golang/ov"
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/hashicorp/terraform/helper/schema"
-	"reflect"
-	"strconv"
 )
 
 func resourceLogicalInterconnectGroup() *schema.Resource {
@@ -563,6 +563,79 @@ func resourceLogicalInterconnectGroup() *schema.Resource {
 					},
 				},
 			},
+			"port_flap_settings": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"uri": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"category": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"etag": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"created": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"modified": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"detection_interval": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"port_flap_threshold_per_interval": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"no_of_samples_declare_failures": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"consistency_checking": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"port_flap_protection_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"quality_of_service": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -651,79 +724,6 @@ func resourceLogicalInterconnectGroup() *schema.Resource {
 					},
 				},
 			},
-			"port_flap_settings": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"uri": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"category": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"eTag": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"created": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"modified": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"detection_interval": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"port_flap_threshold_per_interval": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"no_of_samples_declare_failures": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"consistency_checking": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"port_flap_protection_mode": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"description": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"state": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"status": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
 			"created": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -756,7 +756,7 @@ func resourceLogicalInterconnectGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"eTag": {
+			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -1290,7 +1290,7 @@ func resourceLogicalInterconnectGroupCreate(d *schema.ResourceData, meta interfa
 		portFlapSettingStructure.Type = portFlapSettingRawData["type"].(string)
 		portFlapSettingStructure.URI = utils.Nstring(portFlapSettingRawData["uri"].(string))
 		portFlapSettingStructure.Category = utils.Nstring(portFlapSettingRawData["category"].(string))
-		portFlapSettingStructure.ETAG = portFlapSettingRawData["eTag"].(string)
+		portFlapSettingStructure.ETAG = portFlapSettingRawData["etag"].(string)
 		portFlapSettingStructure.Created = portFlapSettingRawData["created"].(string)
 		portFlapSettingStructure.Modified = portFlapSettingRawData["modified"].(string)
 		portFlapSettingStructure.ID = portFlapSettingRawData["id"].(string)
@@ -1393,7 +1393,6 @@ func resourceLogicalInterconnectGroupCreate(d *schema.ResourceData, meta interfa
 		d.SetId("")
 		return ligError
 	}
-
 	return resourceLogicalInterconnectGroupRead(d, meta)
 }
 
@@ -1401,9 +1400,10 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 	config := meta.(*Config)
 
 	logicalInterconnectGroup, err := config.ovClient.GetLogicalInterconnectGroupByName(d.Id())
+
 	if err != nil || logicalInterconnectGroup.URI.IsNil() {
 		d.SetId("")
-		return err
+		return nil
 	}
 
 	d.Set("name", logicalInterconnectGroup.Name)
@@ -1415,7 +1415,7 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 	d.Set("category", logicalInterconnectGroup.Category)
 	d.Set("state", logicalInterconnectGroup.State)
 	d.Set("fabric_uri", logicalInterconnectGroup.FabricUri.String())
-	d.Set("eTag", logicalInterconnectGroup.ETAG)
+	d.Set("etag", logicalInterconnectGroup.ETAG)
 	d.Set("description", logicalInterconnectGroup.Description)
 	d.Set("interconnect_settings.0.interconnect_utilization_alert", logicalInterconnectGroup.EthernetSettings.EnableInterconnectUtilizationAlert)
 	d.Set("interconnect_bay_set", logicalInterconnectGroup.InterconnectBaySet)
@@ -1757,7 +1757,7 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 			"type":                             logicalInterconnectGroup.PortFlapProtection.Type,
 			"uri":                              logicalInterconnectGroup.PortFlapProtection.URI,
 			"category":                         logicalInterconnectGroup.PortFlapProtection.Category,
-			"eTag":                             logicalInterconnectGroup.PortFlapProtection.ETAG,
+			"etag":                             logicalInterconnectGroup.PortFlapProtection.ETAG,
 			"created":                          logicalInterconnectGroup.PortFlapProtection.Created,
 			"modified":                         logicalInterconnectGroup.PortFlapProtection.Modified,
 			"id":                               logicalInterconnectGroup.PortFlapProtection.ID,
@@ -1777,21 +1777,25 @@ func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface
 
 	qosTrafficClasses := make([]map[string]interface{}, 0, 1)
 	for _, qosTrafficClass := range logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.QosTrafficClassifiers {
-
-		dscpClassMap := make([]interface{}, len(qosTrafficClass.QosClassificationMapping.DscpClassMapping))
-		for i, dscpValue := range qosTrafficClass.QosClassificationMapping.DscpClassMapping {
-			dscpClassMap[i] = dscpValue
-		}
-
-		dot1pClassMap := make([]interface{}, len(qosTrafficClass.QosClassificationMapping.Dot1pClassMapping))
-		for i, dot1pValue := range qosTrafficClass.QosClassificationMapping.Dot1pClassMapping {
-			dot1pClassMap[i] = dot1pValue
-		}
 		qosClassificationMap := make([]map[string]interface{}, 0, 1)
-		qosClassificationMap = append(qosClassificationMap, map[string]interface{}{
-			"dot1p_class_map": schema.NewSet(func(a interface{}) int { return a.(int) }, dot1pClassMap),
-			"dscp_class_map":  schema.NewSet(schema.HashString, dscpClassMap),
-		})
+		if qosTrafficClass.QosClassificationMapping != nil {
+
+			dot1pClassMap := make([]interface{}, 0)
+			for _, raw := range qosTrafficClass.QosClassificationMapping.Dot1pClassMapping {
+				dot1pClassMap = append(dot1pClassMap, raw)
+			}
+
+			dscpClassMap := make([]interface{}, 0)
+			for _, raw := range qosTrafficClass.QosClassificationMapping.DscpClassMapping {
+				dscpClassMap = append(dscpClassMap, raw)
+			}
+
+			qosClassificationMap = append(qosClassificationMap, map[string]interface{}{
+				"dot1p_class_map": dot1pClassMap,
+				"dscp_class_map":  dscpClassMap,
+			})
+
+		}
 
 		qosTrafficClasses = append(qosTrafficClasses, map[string]interface{}{
 			"name":                   qosTrafficClass.QosTrafficClass.ClassName,
@@ -2317,7 +2321,7 @@ func resourceLogicalInterconnectGroupUpdate(d *schema.ResourceData, meta interfa
 		PortFlapSetting.Type = rawlval["type"].(string)
 		PortFlapSetting.URI = utils.Nstring(rawlval["uri"].(string))
 		PortFlapSetting.Category = utils.Nstring(rawlval["category"].(string))
-		PortFlapSetting.ETAG = rawlval["eTag"].(string)
+		PortFlapSetting.ETAG = rawlval["etag"].(string)
 		PortFlapSetting.Created = rawlval["created"].(string)
 		PortFlapSetting.Modified = rawlval["modified"].(string)
 		PortFlapSetting.ID = rawlval["id"].(string)

--- a/oneview/resource_network_set.go
+++ b/oneview/resource_network_set.go
@@ -193,13 +193,13 @@ func resourceNetworkSetUpdate(d *schema.ResourceData, meta interface{}) error {
 		netUris[i] = utils.NewNstring(raw.(string))
 	}
 	newNetSet := ov.NetworkSet{
-		ETAG: d.Get("eTag").(string),
-		URI:  utils.NewNstring(d.Get("uri").(string)),
-		Name: d.Get("name").(string),
+		ETAG:                  d.Get("eTag").(string),
+		URI:                   utils.NewNstring(d.Get("uri").(string)),
+		Name:                  d.Get("name").(string),
 		ConnectionTemplateUri: utils.NewNstring(d.Get("connection_template_uri").(string)),
-		Type:             d.Get("type").(string),
-		NativeNetworkUri: utils.NewNstring(d.Get("native_network_uri").(string)),
-		NetworkUris:      netUris,
+		Type:                  d.Get("type").(string),
+		NativeNetworkUri:      utils.NewNstring(d.Get("native_network_uri").(string)),
+		NetworkUris:           netUris,
 	}
 
 	if val, ok := d.GetOk("network_set_type"); ok {

--- a/oneview/resource_server_profile.go
+++ b/oneview/resource_server_profile.go
@@ -1158,10 +1158,10 @@ func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error
 				}
 				init := controllerData["initialize"].(bool)
 				localStorageEmbeddedController = append(localStorageEmbeddedController, ov.LocalStorageEmbeddedController{
-					DeviceSlot:      controllerData["device_slot"].(string),
-					DriveWriteCache: controllerData["drive_write_cache"].(string),
-					Initialize:      &init,
-					Mode:            controllerData["mode"].(string),
+					DeviceSlot:             controllerData["device_slot"].(string),
+					DriveWriteCache:        controllerData["drive_write_cache"].(string),
+					Initialize:             &init,
+					Mode:                   controllerData["mode"].(string),
 					PredictiveSpareRebuild: controllerData["predictive_spare_rebuild"].(string),
 					LogicalDrives:          logicalDrives,
 				})
@@ -1242,14 +1242,14 @@ func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error
 								IsCompressed:                  propertyItem["is_compressed"].(bool),
 								IsAdaptiveOptimizationEnabled: propertyItem["is_adaptive_optimization_enabled"].(bool),
 								IsDataReductionEnabled:        propertyItem["is_data_reduction_enabled"].(bool),
-								Name:              propertyItem["name"].(string),
-								PerformancePolicy: propertyItem["performance_policy"].(string),
-								ProvisioningType:  propertyItem["provisioning_type"].(string),
-								Size:              propertyItem["size"].(int),
-								SnapshotPool:      utils.NewNstring(propertyItem["snapshot_pool"].(string)),
-								StoragePool:       utils.NewNstring(propertyItem["storage_pool"].(string)),
-								TemplateVersion:   propertyItem["template_version"].(string),
-								VolumeSet:         utils.NewNstring(propertyItem["volume_set"].(string)),
+								Name:                          propertyItem["name"].(string),
+								PerformancePolicy:             propertyItem["performance_policy"].(string),
+								ProvisioningType:              propertyItem["provisioning_type"].(string),
+								Size:                          propertyItem["size"].(int),
+								SnapshotPool:                  utils.NewNstring(propertyItem["snapshot_pool"].(string)),
+								StoragePool:                   utils.NewNstring(propertyItem["storage_pool"].(string)),
+								TemplateVersion:               propertyItem["template_version"].(string),
+								VolumeSet:                     utils.NewNstring(propertyItem["volume_set"].(string)),
 							}
 						}
 					}
@@ -1300,11 +1300,11 @@ func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error
 				VolumeURI:                      utils.NewNstring(volumeAttachmentItem["volume_uri"].(string)),
 				VolumeStorageSystemURI:         utils.NewNstring(volumeAttachmentItem["volume_storage_system_uri"].(string)),
 				AssociatedTemplateAttachmentId: volumeAttachmentItem["associated_template_attachment_id"].(string),
-				State:              volumeAttachmentItem["state"].(string),
-				Status:             volumeAttachmentItem["status"].(string),
-				StoragePaths:       storagePaths,
-				BootVolumePriority: volumeAttachmentItem["boot_volume_priority"].(string),
-				Volume:             &volumes,
+				State:                          volumeAttachmentItem["state"].(string),
+				Status:                         volumeAttachmentItem["status"].(string),
+				StoragePaths:                   storagePaths,
+				BootVolumePriority:             volumeAttachmentItem["boot_volume_priority"].(string),
+				Volume:                         &volumes,
 			})
 		}
 		serverProfile.SanStorage.VolumeAttachments = volumeAttachments
@@ -1475,10 +1475,10 @@ func resourceServerProfileRead(d *schema.ResourceData, meta interface{}) error {
 			})
 		}
 		controllers = append(controllers, map[string]interface{}{
-			"device_slot":       serverProfile.LocalStorage.Controllers[i].DeviceSlot,
-			"initialize":        serverProfile.LocalStorage.Controllers[i].Initialize,
-			"drive_write_cache": serverProfile.LocalStorage.Controllers[i].DriveWriteCache,
-			"mode":              serverProfile.LocalStorage.Controllers[i].Mode,
+			"device_slot":              serverProfile.LocalStorage.Controllers[i].DeviceSlot,
+			"initialize":               serverProfile.LocalStorage.Controllers[i].Initialize,
+			"drive_write_cache":        serverProfile.LocalStorage.Controllers[i].DriveWriteCache,
+			"mode":                     serverProfile.LocalStorage.Controllers[i].Mode,
 			"predictive_spare_rebuild": serverProfile.LocalStorage.Controllers[i].PredictiveSpareRebuild,
 			"logical_drive":            logicalDrives,
 		})
@@ -1788,10 +1788,10 @@ func resourceServerProfileUpdate(d *schema.ResourceData, meta interface{}) error
 					}
 					init := controllerData["initialize"].(bool)
 					localStorageEmbeddedController = append(localStorageEmbeddedController, ov.LocalStorageEmbeddedController{
-						DeviceSlot:      controllerData["device_slot"].(string),
-						DriveWriteCache: controllerData["drive_write_cache"].(string),
-						Initialize:      &init,
-						Mode:            controllerData["mode"].(string),
+						DeviceSlot:             controllerData["device_slot"].(string),
+						DriveWriteCache:        controllerData["drive_write_cache"].(string),
+						Initialize:             &init,
+						Mode:                   controllerData["mode"].(string),
 						PredictiveSpareRebuild: controllerData["predictive_spare_rebuild"].(string),
 						LogicalDrives:          logicalDrives,
 					})
@@ -1871,14 +1871,14 @@ func resourceServerProfileUpdate(d *schema.ResourceData, meta interface{}) error
 									IsCompressed:                  propertyItem["is_compressed"].(bool),
 									IsAdaptiveOptimizationEnabled: propertyItem["is_adaptive_optimization_enabled"].(bool),
 									IsDataReductionEnabled:        propertyItem["is_data_reduction_enabled"].(bool),
-									Name:              propertyItem["name"].(string),
-									PerformancePolicy: propertyItem["performance_policy"].(string),
-									ProvisioningType:  propertyItem["provisioning_type"].(string),
-									Size:              propertyItem["size"].(int),
-									SnapshotPool:      utils.NewNstring(propertyItem["snapshot_pool"].(string)),
-									StoragePool:       utils.NewNstring(propertyItem["storage_pool"].(string)),
-									TemplateVersion:   propertyItem["template_version"].(string),
-									VolumeSet:         utils.NewNstring(propertyItem["volume_set"].(string)),
+									Name:                          propertyItem["name"].(string),
+									PerformancePolicy:             propertyItem["performance_policy"].(string),
+									ProvisioningType:              propertyItem["provisioning_type"].(string),
+									Size:                          propertyItem["size"].(int),
+									SnapshotPool:                  utils.NewNstring(propertyItem["snapshot_pool"].(string)),
+									StoragePool:                   utils.NewNstring(propertyItem["storage_pool"].(string)),
+									TemplateVersion:               propertyItem["template_version"].(string),
+									VolumeSet:                     utils.NewNstring(propertyItem["volume_set"].(string)),
 								}
 							}
 						}
@@ -1929,11 +1929,11 @@ func resourceServerProfileUpdate(d *schema.ResourceData, meta interface{}) error
 					VolumeURI:                      utils.NewNstring(volumeAttachmentItem["volume_uri"].(string)),
 					VolumeStorageSystemURI:         utils.NewNstring(volumeAttachmentItem["volume_storage_system_uri"].(string)),
 					AssociatedTemplateAttachmentId: volumeAttachmentItem["associated_template_attachment_id"].(string),
-					State:              volumeAttachmentItem["state"].(string),
-					Status:             volumeAttachmentItem["status"].(string),
-					StoragePaths:       storagePaths,
-					BootVolumePriority: volumeAttachmentItem["boot_volume_priority"].(string),
-					Volume:             &volumes,
+					State:                          volumeAttachmentItem["state"].(string),
+					Status:                         volumeAttachmentItem["status"].(string),
+					StoragePaths:                   storagePaths,
+					BootVolumePriority:             volumeAttachmentItem["boot_volume_priority"].(string),
+					Volume:                         &volumes,
 				})
 			}
 			serverProfile.SanStorage.VolumeAttachments = volumeAttachments

--- a/oneview/resource_storage_pool.go
+++ b/oneview/resource_storage_pool.go
@@ -157,12 +157,12 @@ func resourceStoragePoolRead(d *schema.ResourceData, meta interface{}) error {
 	rawdevspecificattributes := storagePool.DeviceSpecificAttributes
 	devspecificattributes := make([]map[string]interface{}, 0)
 	devspecificattributes = append(devspecificattributes, map[string]interface{}{
-		"device_id":            rawdevspecificattributes.DeviceID,
-		"capacity_limit":       rawdevspecificattributes.CapacityLimit,
-		"device_speed":         rawdevspecificattributes.DeviceSpeed,
-		"domain":               rawdevspecificattributes.Domain,
-		"supported_raid_level": rawdevspecificattributes.SupportedRaidLevel,
-		"uuid":                 rawdevspecificattributes.Uuid,
+		"device_id":                rawdevspecificattributes.DeviceID,
+		"capacity_limit":           rawdevspecificattributes.CapacityLimit,
+		"device_speed":             rawdevspecificattributes.DeviceSpeed,
+		"domain":                   rawdevspecificattributes.Domain,
+		"supported_raid_level":     rawdevspecificattributes.SupportedRaidLevel,
+		"uuid":                     rawdevspecificattributes.Uuid,
 		"is_deduplication_capable": rawdevspecificattributes.IsDeduplicationCapable,
 	})
 	d.Set("storage_pool_device_specific_attributes", devspecificattributes)

--- a/oneview/resource_uplink_set.go
+++ b/oneview/resource_uplink_set.go
@@ -154,12 +154,12 @@ func resourceUplinkSetCreate(d *schema.ResourceData, meta interface{}) error {
 	const Port = "Port"
 
 	uplinkSet := ov.UplinkSet{
-		Name: d.Get("name").(string),
-		LogicalInterconnectURI: utils.NewNstring(d.Get("logical_interconnect_uri").(string)),
-		ConnectionMode:         d.Get("connection_mode").(string),
-		NetworkType:            d.Get("network_type").(string),
-		EthernetNetworkType:    d.Get("ethernet_network_type").(string),
-		Type:                   d.Get("type").(string),
+		Name:                           d.Get("name").(string),
+		LogicalInterconnectURI:         utils.NewNstring(d.Get("logical_interconnect_uri").(string)),
+		ConnectionMode:                 d.Get("connection_mode").(string),
+		NetworkType:                    d.Get("network_type").(string),
+		EthernetNetworkType:            d.Get("ethernet_network_type").(string),
+		Type:                           d.Get("type").(string),
 		ManualLoginRedistributionState: d.Get("manual_login_redistribution_state").(string),
 	}
 
@@ -287,13 +287,13 @@ func resourceUplinkSetUpdate(d *schema.ResourceData, meta interface{}) error {
 	const Port = "Port"
 
 	uplinkSet := ov.UplinkSet{
-		Name: d.Get("name").(string),
-		LogicalInterconnectURI: utils.NewNstring(d.Get("logical_interconnect_uri").(string)),
-		ConnectionMode:         d.Get("connection_mode").(string),
-		NetworkType:            d.Get("network_type").(string),
-		EthernetNetworkType:    d.Get("ethernet_network_type").(string),
-		Type:                   d.Get("type").(string),
-		URI:                    utils.NewNstring(d.Get("uri").(string)),
+		Name:                           d.Get("name").(string),
+		LogicalInterconnectURI:         utils.NewNstring(d.Get("logical_interconnect_uri").(string)),
+		ConnectionMode:                 d.Get("connection_mode").(string),
+		NetworkType:                    d.Get("network_type").(string),
+		EthernetNetworkType:            d.Get("ethernet_network_type").(string),
+		Type:                           d.Get("type").(string),
+		URI:                            utils.NewNstring(d.Get("uri").(string)),
 		ManualLoginRedistributionState: d.Get("manual_login_redistribution_state").(string),
 	}
 


### PR DESCRIPTION
### Description
TF Crashes for Read in LIG due to the bug in LIG Read method while collecting Qos attributes.
This Pr is for Terraform-0.11 branch

This PR fixed formatting issues in below files as well :-

oneview/data_source_interconnect_type.go
oneview/data_source_logical_interconnect_group.go
oneview/data_source_server_profile.go
oneview/data_source_server_profile_template.go
oneview/data_source_storage_pool.go
oneview/resource_enclosure_group.go
oneview/resource_ethernet_network.go
oneview/resource_fc_network.go
oneview/resource_fcoe_network.go
oneview/resource_hypervisor_cluster_profile.go
oneview/resource_network_set.go
oneview/resource_server_profile.go
oneview/resource_storage_pool.go
 oneview/resource_uplink_set.go

### Issues Resolved
#285 

### Check List
- [x] New functionality includes testing.
  - [x]  All tests pass for go 1.11 + gofmt checks.
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.