### PR TITLE
Fix issue #414 / Faulty logic for fetching server hardware after creation or import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bug fixes & Enhancements:
 - [#404](https://github.com/HewlettPackard/terraform-provider-oneview/issues/404) Creating Server profile for DLs fails
-- [#416](https://github.com/HewlettPackard/terraform-provider-oneview/issues/416) server hardware resource is not idempotent 
+- [#414](https://github.com/HewlettPackard/terraform-provider-oneview/issues/414) Adding DLs servers in OneView fails
+- [#416](https://github.com/HewlettPackard/terraform-provider-oneview/issues/416) server hardware resource is not idempotent
 
 # [v6.3.1-13]
 

--- a/oneview/resource_server_hardware.go
+++ b/oneview/resource_server_hardware.go
@@ -207,13 +207,13 @@ func getServerHardwareByiLO(c *ov.OVClient, query string) (ov.ServerHardware, er
 	filter := fmt.Sprintf("mpHostInfo.mpIpAddresses[].address == '%s'", query)
 	list, err := c.GetServerHardwareList([]string{filter}, "", "", "1", "")
 	if list.Total > 0 {
-			return list.Members[0], err
+		return list.Members[0], err
 	}
 
 	filter = fmt.Sprintf("mpHostInfo.mpHostName == '%s'", query)
 	list, err = c.GetServerHardwareList([]string{filter}, "", "", "1", "")
 	if list.Total > 0 {
-			return list.Members[0], err
+		return list.Members[0], err
 	}
 
 	return ov.ServerHardware{}, err
@@ -221,27 +221,27 @@ func getServerHardwareByiLO(c *ov.OVClient, query string) (ov.ServerHardware, er
 
 func resourceServerHardwareRead(d *schema.ResourceData, meta interface{}) error {
 	var (
-			servHard ov.ServerHardware
-			err      error
+		servHard ov.ServerHardware
+		err      error
 	)
 	config := meta.(*Config)
 
 	// fetching server hardware through iLO host information
 	if val, ok := d.GetOk("hostname"); ok {
-			servHard, err = getServerHardwareByiLO(config.ovClient, val.(string))
+		servHard, err = getServerHardwareByiLO(config.ovClient, val.(string))
 	} else {
-			// for refreshing imported server hardware we would need it's name
-			if val, ok := d.GetOk("name"); ok {
-					servHard, err = config.ovClient.GetServerHardwareByName(val.(string))
-			} else {
-					// for importing server hardware
-					servHard, err = config.ovClient.GetServerHardwareByUri(utils.NewNstring(d.Id()))
-			}
+		// for refreshing imported server hardware we would need it's name
+		if val, ok := d.GetOk("name"); ok {
+			servHard, err = config.ovClient.GetServerHardwareByName(val.(string))
+		} else {
+			// for importing server hardware
+			servHard, err = config.ovClient.GetServerHardwareByUri(utils.NewNstring(d.Id()))
+		}
 	}
 
 	if err != nil || servHard.URI.IsNil() {
-			d.SetId("")
-			return fmt.Errorf("unable to retrieve server hardware %s", err)
+		d.SetId("")
+		return fmt.Errorf("unable to retrieve server hardware %s", err)
 	}
 
 	// setting UUID as resource Id


### PR DESCRIPTION
### Description
#### The problem
There were a few problems regarding the logic used in the `resourceServerHardwareRead` function that caused creating or importing `oneview_server_hardware` resources to fail as outlined in #414.

Mainly, the `ov.OVClient#GetServerHardwareByName` method is used in the wrong places. On resource creation, only the iLO hostname or IP is known and that data is passed into said method. The problem here is that the method looks up server hardware by their name in OneView, which logically is completely unrelated to both the iLO hostname or IP address. The existing logic often worked out when the iLO hostname was used to create the resource because the iLO hostname (e.g. `esx-x.domain.local`) would be matched by the name given to the hardware in OneView, e.g. `esx-x`. But as soon as you try to add the server hardware using the iLO IP, the issue becomes apparent because the method cannot find the server hardware anymore. Overall this should be counted as a bug.

#### The fix
- I implemented a utility function called `getServerHardwareByiLO` that will fetch server hardware by specifying filters making two requests, one of them filtering for the iLO IP address and the other one filtering for the iLO hostname. This way the `hostname` parameter in the `oneview_server_hardware` resource is appropriately handled.
- Importing server hardware did not work due to the wrong method being used for that action. As the parameter given in the terraform CLI to import the hardware resource is the resource URI, the method `ov.OVClient#GetServerHardwareByUri` should be used instead of `ov.OVClient#GetServerHardwareByName`.

#### Testing
I have tested both the resource creation using IPv4 and resource importing using the URI but haven't been able to see whether using the iLO hostname still works, so I would appreciate it if someone could quickly try that out in their OV instance.

### Issues Resolved
Fixes #414

### Check List
- [x] New functionality includes testing.
  - [x]  All tests pass for go 1.11 + gofmt checks.
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.