### PR TITLE
Used server hardware uri to get resource and not name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bug fixes & Enhancements:
 - [#404](https://github.com/HewlettPackard/terraform-provider-oneview/issues/404) Creating Server profile for DLs fails
 - [#416](https://github.com/HewlettPackard/terraform-provider-oneview/issues/416) server hardware resource is not idempotent 
+- [#414](https://github.com/HewlettPackard/terraform-provider-oneview/issues/414) Adding DLs servers in OneView fails 
 
 # [v6.3.1-13]
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HewlettPackard/terraform-provider-oneview
 go 1.15
 
 require (
-	github.com/HewlettPackard/oneview-golang v6.3.1-0.20211011135008-5aba37c2aa6c+incompatible
+	github.com/HewlettPackard/oneview-golang v6.3.1-0.20211028120403-11d8bc7358c1+incompatible
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/docker/machine v0.16.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/HewlettPackard/oneview-golang v6.3.1-0.20211011135008-5aba37c2aa6c+incompatible h1:nhtyiIrL64sxupym58kYldaY98ZIepu7TcfXTYEH+/s=
-github.com/HewlettPackard/oneview-golang v6.3.1-0.20211011135008-5aba37c2aa6c+incompatible/go.mod h1:GJcjWgNHrKtt2lUl4xcaV3NRiuBlG138DNrFygXj4JE=
+github.com/HewlettPackard/oneview-golang v6.3.1-0.20211028120403-11d8bc7358c1+incompatible h1:KzpdbhbvuXQeIuXtt3RQd/Q1kkhC1oywP4pdjVLzuoA=
+github.com/HewlettPackard/oneview-golang v6.3.1-0.20211028120403-11d8bc7358c1+incompatible/go.mod h1:GJcjWgNHrKtt2lUl4xcaV3NRiuBlG138DNrFygXj4JE=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/oneview/resource_server_hardware.go
+++ b/oneview/resource_server_hardware.go
@@ -192,8 +192,8 @@ func resourceServerHardwareCreate(d *schema.ResourceData, meta interface{}) erro
 		hardware.InitialScopeUris = initialScopeUris
 	}
 
-	resourceUri, err := config.ovClient.AddRackServer(hardware)
-	if err != nil && resourceUri != "" {
+	resourceURI, err := config.ovClient.AddRackServer(hardware)
+	if err != nil && resourceURI != "" {
 		d.SetId("")
 		return err
 	}
@@ -201,7 +201,7 @@ func resourceServerHardwareCreate(d *schema.ResourceData, meta interface{}) erro
 	sh, _ := config.ovClient.GetServerHardwareByName(d.Get("hostname").(string))
 
 	d.SetId(sh.UUID.String())
-	d.Set("uri", resourceUri)
+	d.Set("uri", resourceURI)
 	return resourceServerHardwareRead(d, meta)
 }
 

--- a/oneview/resource_server_hardware.go
+++ b/oneview/resource_server_hardware.go
@@ -198,9 +198,6 @@ func resourceServerHardwareCreate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	sh, _ := config.ovClient.GetServerHardwareByName(d.Get("hostname").(string))
-
-	d.SetId(sh.UUID.String())
 	d.Set("uri", resourceURI)
 	return resourceServerHardwareRead(d, meta)
 }

--- a/oneview/resource_server_hardware.go
+++ b/oneview/resource_server_hardware.go
@@ -192,8 +192,8 @@ func resourceServerHardwareCreate(d *schema.ResourceData, meta interface{}) erro
 		hardware.InitialScopeUris = initialScopeUris
 	}
 
-	resource_uri, err := config.ovClient.AddRackServer(hardware)
-	if err != nil && resource_uri != "" {
+	resourceUri, err := config.ovClient.AddRackServer(hardware)
+	if err != nil && resourceUri != "" {
 		d.SetId("")
 		return err
 	}
@@ -201,7 +201,7 @@ func resourceServerHardwareCreate(d *schema.ResourceData, meta interface{}) erro
 	sh, _ := config.ovClient.GetServerHardwareByName(d.Get("hostname").(string))
 
 	d.SetId(sh.UUID.String())
-	d.Set("uri", resource_uri)
+	d.Set("uri", resourceUri)
 	return resourceServerHardwareRead(d, meta)
 }
 

--- a/oneview/resource_server_hardware.go
+++ b/oneview/resource_server_hardware.go
@@ -192,8 +192,8 @@ func resourceServerHardwareCreate(d *schema.ResourceData, meta interface{}) erro
 		hardware.InitialScopeUris = initialScopeUris
 	}
 
-	err := config.ovClient.AddRackServer(hardware)
-	if err != nil {
+	resource_uri, err := config.ovClient.AddRackServer(hardware)
+	if err != nil && resource_uri != "" {
 		d.SetId("")
 		return err
 	}
@@ -201,6 +201,7 @@ func resourceServerHardwareCreate(d *schema.ResourceData, meta interface{}) erro
 	sh, _ := config.ovClient.GetServerHardwareByName(d.Get("hostname").(string))
 
 	d.SetId(sh.UUID.String())
+	d.Set("uri", resource_uri)
 	return resourceServerHardwareRead(d, meta)
 }
 
@@ -212,8 +213,8 @@ func resourceServerHardwareRead(d *schema.ResourceData, meta interface{}) error 
 	config := meta.(*Config)
 
 	// fetching server hardware hostname incase it's added
-	if val, ok := d.GetOk("hostname"); ok {
-		servHard, err = config.ovClient.GetServerHardwareByName(val.(string))
+	if _, ok := d.GetOk("uri"); ok {
+		servHard, err = config.ovClient.GetServerHardwareByUri(utils.Nstring(d.Get("uri").(string)))
 	} else {
 		// for refreshing imported server hardware we would need it's name
 		if val, ok := d.GetOk("name"); ok {

--- a/vendor/github.com/HewlettPackard/oneview-golang/ov/server_hardware.go
+++ b/vendor/github.com/HewlettPackard/oneview-golang/ov/server_hardware.go
@@ -227,7 +227,7 @@ func (s ServerHardware) GetPowerState() (PowerState, error) {
 }
 
 // Add single rack server to the appliance
-func (c *OVClient) AddRackServer(rackServer ServerHardware) error {
+func (c *OVClient) AddRackServer(rackServer ServerHardware) (utils.Nstring, error) {
 	log.Infof("Adding rack server %s.", rackServer.Hostname)
 	var (
 		uri = "/rest/server-hardware"
@@ -242,25 +242,27 @@ func (c *OVClient) AddRackServer(rackServer ServerHardware) error {
 	log.Debugf("REST : %s \n %+v\n", uri, rackServer)
 	log.Debugf("task -> %+v", t)
 	data, err := c.RestAPICall(rest.POST, uri, rackServer)
+
 	if err != nil {
 		t.TaskIsDone = true
 		log.Errorf("Error submitting new rack server addition: %s", err)
-		return err
+		return t.AssociatedRes.ResourceURI, err
 	}
 
 	log.Debugf("Response New Rackserver %s", data)
 	if err := json.Unmarshal([]byte(data), &t); err != nil {
 		t.TaskIsDone = true
 		log.Errorf("Error with task un-marshal: %s", err)
-		return err
+		return t.AssociatedRes.ResourceURI, err
 	}
 
 	err = t.Wait()
+
 	if err != nil {
-		return err
+		return t.AssociatedRes.ResourceURI, err
 	}
 
-	return nil
+	return t.AssociatedRes.ResourceURI, nil
 }
 
 // Add multiple rack servers

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/HewlettPackard/oneview-golang v6.3.1-0.20211011135008-5aba37c2aa6c+incompatible
+# github.com/HewlettPackard/oneview-golang v6.3.1-0.20211028120403-11d8bc7358c1+incompatible
 ## explicit
 github.com/HewlettPackard/oneview-golang/i3s
 github.com/HewlettPackard/oneview-golang/liboneview


### PR DESCRIPTION
### Description
[Use resource from task reponse to query the server hardware instead of using name]

### Issues Resolved
#414 
### Check List
- [ ] New functionality includes testing.
  - [x]  All tests pass for go 1.11 + gofmt checks.
- [x] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.