### PR TITLE
Fix for issue 412 to use fw name and version in datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
+# [v6.5.0-13] (unreleased)
+### Notes
+- This release supports API3600 minimally where we can use OneView v6.50 with this SDK.
 
-# [v6.4.0-13](unreleased)
+#### Major Changes
+
+ 
+
+### Bug fixes & Enhancements:
+
+- [#412](https://github.com/HewlettPackard/terraform-provider-oneview/issues/412) Use firmware baseline name instead of uri - enhancement needed
+
+
+# [v6.4.0-13]
 ### Notes
 - This release supports API3400 minimally where we can use OneView v6.40 with this SDK.
 

--- a/docs/d/firmware_drivers.html.markdown
+++ b/docs/d/firmware_drivers.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access the attributes of a firmware baseline.
 
 ```hcl
 data "oneview_firmware_drivers" "test" {
- id = "Synergy_Custom_SPP_2021_02_01_Z7550-97110"
+ id = "HPE Synergy Service Pack,SY-2021.11.01"
 }
 
 output "oneview_firmware_drivers_value" {
@@ -24,7 +24,7 @@ output "oneview_firmware_drivers_value" {
 
 ## Argument Reference
 
-* `id` - (Required) The id of the resource.
+* `id` - (Required) The name of firmware and version separated by comma. Or you can use jsut name also. For E.g. "HPE Synergy Service Pack,SY-2021.11.01"
 
 ## Attributes Reference
 

--- a/examples/firmware_drivers/data_source.tf
+++ b/examples/firmware_drivers/data_source.tf
@@ -1,15 +1,15 @@
 provider "oneview" {
-	ov_username   = var.username
-	ov_password   = var.password
-	ov_endpoint   = var.endpoint
-	ov_sslverify  = var.ssl_enabled
-	ov_apiversion = var.api_version
-	ov_ifmatch    = "*"
-  }
-  
+  ov_username   = var.username
+  ov_password   = var.password
+  ov_endpoint   = var.endpoint
+  ov_sslverify  = var.ssl_enabled
+  ov_apiversion = var.api_version
+  ov_ifmatch    = "*"
+}
+
 # Testing data source
 data "oneview_firmware_drivers" "drivers" {
-  id = "Synergy_Custom_SPP_2021_02_01_Z7550-97110"
+  id = "HPE Synergy Service Pack,SY-2021.11.01"
 }
 
 output "firmware_drivers_value" {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HewlettPackard/terraform-provider-oneview
 go 1.15
 
 require (
-	github.com/HewlettPackard/oneview-golang v6.4.1-0.20211206111212-57ddb7e9b984+incompatible
+	github.com/HewlettPackard/oneview-golang v6.4.1-0.20211207103755-542200727968+incompatible
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/docker/machine v0.16.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HewlettPackard/terraform-provider-oneview
 go 1.15
 
 require (
-	github.com/HewlettPackard/oneview-golang v6.4.0+incompatible
+	github.com/HewlettPackard/oneview-golang v6.4.1-0.20211206111212-57ddb7e9b984+incompatible
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/docker/machine v0.16.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/HewlettPackard/oneview-golang v6.4.1-0.20211206111212-57ddb7e9b984+incompatible h1:u8WbHMUT1kIZxlbjkPosoTrBXxK1cFjVk4XJ7PeqxWE=
-github.com/HewlettPackard/oneview-golang v6.4.1-0.20211206111212-57ddb7e9b984+incompatible/go.mod h1:GJcjWgNHrKtt2lUl4xcaV3NRiuBlG138DNrFygXj4JE=
+github.com/HewlettPackard/oneview-golang v6.4.1-0.20211207103755-542200727968+incompatible h1:Ax9wQvNdV1GRYkjIO/A9D0dA0e8zN1bM0dntbBSKT1A=
+github.com/HewlettPackard/oneview-golang v6.4.1-0.20211207103755-542200727968+incompatible/go.mod h1:GJcjWgNHrKtt2lUl4xcaV3NRiuBlG138DNrFygXj4JE=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/HewlettPackard/oneview-golang v6.4.0+incompatible h1:zzhjemZIywwc4PZinUVmwntUVak6rKd6q0wptRek+rY=
-github.com/HewlettPackard/oneview-golang v6.4.0+incompatible/go.mod h1:GJcjWgNHrKtt2lUl4xcaV3NRiuBlG138DNrFygXj4JE=
+github.com/HewlettPackard/oneview-golang v6.4.1-0.20211206111212-57ddb7e9b984+incompatible h1:u8WbHMUT1kIZxlbjkPosoTrBXxK1cFjVk4XJ7PeqxWE=
+github.com/HewlettPackard/oneview-golang v6.4.1-0.20211206111212-57ddb7e9b984+incompatible/go.mod h1:GJcjWgNHrKtt2lUl4xcaV3NRiuBlG138DNrFygXj4JE=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/oneview/data_source_firmware_drivers.go
+++ b/oneview/data_source_firmware_drivers.go
@@ -237,10 +237,12 @@ func dataSourceFirmwareDrivers() *schema.Resource {
 func dataSourceFirmwareDriversRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	id := d.Get("id").(string)
-	firmware, err := config.ovClient.GetFirmwareBaselineById(id)
+	firmware, err := config.ovClient.GetFirmwareBaselineByNameandVersion(id)
+
 	if err != nil || firmware.Uri.IsNil() {
+
 		d.SetId("")
-		return nil
+		return err
 	}
 	d.Set("name", firmware.Name)
 	d.Set("type", firmware.Type)

--- a/oneview/resource_server_hardware.go
+++ b/oneview/resource_server_hardware.go
@@ -15,10 +15,11 @@ import (
 	"errors"
 	"fmt"
 
+	"log"
+
 	"github.com/HewlettPackard/oneview-golang/ov"
 	"github.com/HewlettPackard/oneview-golang/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"log"
 )
 
 func resourceServerHardware() *schema.Resource {
@@ -193,6 +194,7 @@ func resourceServerHardwareCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	resourceURI, err := config.ovClient.AddRackServer(hardware)
+
 	if err != nil && resourceURI != "" {
 		d.SetId("")
 		return err

--- a/vendor/github.com/HewlettPackard/oneview-golang/ov/firmware_drivers.go
+++ b/vendor/github.com/HewlettPackard/oneview-golang/ov/firmware_drivers.go
@@ -154,7 +154,7 @@ func (c *OVClient) GetFirmwareBaselineByNameandVersion(name string) (FirmwareDri
 		return FirmwareDrivers{}, errors.New("firmware name not provided")
 	}
 	if len(fwNameVersion) == 2 {
-		fwname, version = fwNameVersion[0], fwNameVersion[1]
+		fwname, version = strings.TrimSpace(fwNameVersion[0]), strings.TrimSpace(fwNameVersion[1])
 	} else {
 		fwname = fwNameVersion[0]
 	}

--- a/vendor/github.com/HewlettPackard/oneview-golang/ov/firmware_drivers.go
+++ b/vendor/github.com/HewlettPackard/oneview-golang/ov/firmware_drivers.go
@@ -2,6 +2,8 @@ package ov
 
 import (
 	"encoding/json"
+	"errors"
+	"strings"
 
 	"github.com/HewlettPackard/oneview-golang/rest"
 	"github.com/HewlettPackard/oneview-golang/utils"
@@ -143,6 +145,31 @@ func (c *OVClient) GetFirmwareBaselineById(id string) (FirmwareDrivers, error) {
 		return firmwareId, err
 	}
 	return firmwareId, nil
+}
+
+func (c *OVClient) GetFirmwareBaselineByNameandVersion(name string) (FirmwareDrivers, error) {
+	fwNameVersion := strings.SplitAfter(name, ",")
+	if len(fwNameVersion) < 2 {
+		return FirmwareDrivers{}, errors.New("provide firmware name and version separated by comma")
+	}
+	fwname, version := fwNameVersion[0], fwNameVersion[1]
+
+	firmwareList, err := c.GetFirmwareBaselineList("", "", "")
+
+	if firmwareList.Total > 0 {
+
+		for i := range firmwareList.Members {
+			if firmwareList.Members[i].Name != fwname && firmwareList.Members[i].Version != version {
+				continue
+			} else {
+
+				return firmwareList.Members[i], err
+
+			}
+		}
+
+	}
+	return FirmwareDrivers{}, err
 }
 
 func (c *OVClient) CreateCustomServicePack(sp CustomServicePack, force string) error {

--- a/vendor/github.com/HewlettPackard/oneview-golang/ov/firmware_drivers.go
+++ b/vendor/github.com/HewlettPackard/oneview-golang/ov/firmware_drivers.go
@@ -148,24 +148,41 @@ func (c *OVClient) GetFirmwareBaselineById(id string) (FirmwareDrivers, error) {
 }
 
 func (c *OVClient) GetFirmwareBaselineByNameandVersion(name string) (FirmwareDrivers, error) {
+	var fwname, version string
 	fwNameVersion := strings.SplitAfter(name, ",")
-	if len(fwNameVersion) < 2 {
-		return FirmwareDrivers{}, errors.New("provide firmware name and version separated by comma")
+	if len(fwNameVersion) < 1 {
+		return FirmwareDrivers{}, errors.New("firmware name not provided")
 	}
-	fwname, version := fwNameVersion[0], fwNameVersion[1]
+	if len(fwNameVersion) == 2 {
+		fwname, version = fwNameVersion[0], fwNameVersion[1]
+	} else {
+		fwname = fwNameVersion[0]
+	}
 
 	firmwareList, err := c.GetFirmwareBaselineList("", "", "")
 
 	if firmwareList.Total > 0 {
 
 		for i := range firmwareList.Members {
-			if firmwareList.Members[i].Name != fwname && firmwareList.Members[i].Version != version {
-				continue
+			if version != "" {
+				if firmwareList.Members[i].Name != fwname && firmwareList.Members[i].Version != version {
+					continue
+				} else {
+
+					return firmwareList.Members[i], err
+
+				}
+
 			} else {
+				if firmwareList.Members[i].Name != fwname {
+					continue
+				} else {
 
-				return firmwareList.Members[i], err
+					return firmwareList.Members[i], err
 
+				}
 			}
+
 		}
 
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/HewlettPackard/oneview-golang v6.4.0+incompatible
+# github.com/HewlettPackard/oneview-golang v6.4.1-0.20211206111212-57ddb7e9b984+incompatible
 ## explicit
 github.com/HewlettPackard/oneview-golang/i3s
 github.com/HewlettPackard/oneview-golang/liboneview

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/HewlettPackard/oneview-golang v6.4.1-0.20211206111212-57ddb7e9b984+incompatible
+# github.com/HewlettPackard/oneview-golang v6.4.1-0.20211207103755-542200727968+incompatible
 ## explicit
 github.com/HewlettPackard/oneview-golang/i3s
 github.com/HewlettPackard/oneview-golang/liboneview


### PR DESCRIPTION
### Description
[Fix for issue 412 to use fw name and version in datasource]

### Issues Resolved
[#412 ]

### Check List
- [ ] New functionality includes testing.
  - [ ]  All tests pass for go 1.11 + gofmt checks.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.