### PR TITLE
return MAC address with connections in server_profile

### DIFF
--- a/oneview/data_source_server_profile.go
+++ b/oneview/data_source_server_profile.go
@@ -1361,6 +1361,7 @@ func dataSourceServerProfileRead(d *schema.ResourceData, meta interface{}) error
 				"name":           connection.Name,
 				"isolated_trunk": connection.IsolatedTrunk,
 				"lag_name":       connection.LagName,
+				"mac":            connection.MAC,
 				"mac_type":       connection.MacType,
 				"managed":        connection.Managed,
 				"network_name":   connection.NetworkName,


### PR DESCRIPTION
### Description
Noticed that the MAC address per connection were empty when using fetching the server_profile using data. This will add the MAC address to the returned data structure.

### Issues Resolved
None.

### Check List
- [ ] New functionality includes testing.
  - [ ]  All tests pass for go 1.11 + gofmt checks.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.