### PR TITLE
feat(serverprofile): add force param to serverprofile creation

### DIFF
--- a/docs/r/server_profile.html.markdown
+++ b/docs/r/server_profile.html.markdown
@@ -149,6 +149,7 @@ The following arguments are supported:
 * `Operation_type` - (Optional) patch operation can be performed by giving the update string for given type of update. 
 
 - - -
+* `force_flags` - (Optional) a list of supported force flags, ignoring certain warnings when creating the server profile. 
 
 * `public_connection` - (Optional) The name of the network that is going out to the public.
 

--- a/examples/server_profiles/main.tf
+++ b/examples/server_profiles/main.tf
@@ -26,6 +26,9 @@ resource "oneview_server_profile" "SPWithLocalStorage" {
   hardware_name      = "0000A66101, bay 5"
   type               = "ServerProfileV12"
   enclosure_group    = "Auto-EG"
+
+  force_flags = ["ignoreServerHealth"] // supported: ignoreSANWarnings, ignoreServerHealth, ignoreLSWarnings, all; default: none
+
   initial_scope_uris = [data.oneview_scope.scope.uri]
   bios_option {
     manage_bios = true

--- a/examples/server_profiles/update_resource.tf
+++ b/examples/server_profiles/update_resource.tf
@@ -13,6 +13,9 @@ resource "oneview_server_profile" "SP" {
   hardware_name   = "0000A66102, bay 3"
   type            = "ServerProfileV12"
   enclosure_group = "EG"
+
+  force_flags = ["ignoreServerHealth"] // supported: ignoreSANWarnings, ignoreServerHealth, ignoreLSWarnings, all; default: none
+
   bios_option {
     manage_bios = true
     overridden_settings {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HewlettPackard/terraform-provider-oneview
 go 1.15
 
 require (
-	github.com/HewlettPackard/oneview-golang v8.6.0+incompatible
+	github.com/HewlettPackard/oneview-golang v8.6.1-0.20231109094213-30a3fb89caf6+incompatible
 	github.com/docker/machine v0.16.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-getter v1.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,14 +34,10 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/HewlettPackard/oneview-golang v8.3.1-0.20230529095956-f6039fe84f3f+incompatible h1:8COeVoPlFSy1Bo79TazBKGLhj2L1gLcLHHAh/BnFuuc=
-github.com/HewlettPackard/oneview-golang v8.3.1-0.20230529095956-f6039fe84f3f+incompatible/go.mod h1:GJcjWgNHrKtt2lUl4xcaV3NRiuBlG138DNrFygXj4JE=
-github.com/HewlettPackard/oneview-golang v8.4.0+incompatible h1:IR44tRzdZrPmp0Mm1+Adk+z9eDWV+LA2FU23JYKSJOI=
-github.com/HewlettPackard/oneview-golang v8.4.0+incompatible/go.mod h1:GJcjWgNHrKtt2lUl4xcaV3NRiuBlG138DNrFygXj4JE=
-github.com/HewlettPackard/oneview-golang v8.5.0+incompatible h1:Fy7Ce1PUcLk7iuuof494D5cfoSwj/nIWpBkAWnZ4rZY=
-github.com/HewlettPackard/oneview-golang v8.5.0+incompatible/go.mod h1:GJcjWgNHrKtt2lUl4xcaV3NRiuBlG138DNrFygXj4JE=
 github.com/HewlettPackard/oneview-golang v8.6.0+incompatible h1:5/s9xGTGiVyISxWaxT/QlVYx/bIQvCyQo4UA9VgX0Ek=
 github.com/HewlettPackard/oneview-golang v8.6.0+incompatible/go.mod h1:GJcjWgNHrKtt2lUl4xcaV3NRiuBlG138DNrFygXj4JE=
+github.com/HewlettPackard/oneview-golang v8.6.1-0.20231109094213-30a3fb89caf6+incompatible h1:wldabw1+dMd4Pa2ByJ3iV18uFC8pFMxPZO5Q4D3dnq0=
+github.com/HewlettPackard/oneview-golang v8.6.1-0.20231109094213-30a3fb89caf6+incompatible/go.mod h1:GJcjWgNHrKtt2lUl4xcaV3NRiuBlG138DNrFygXj4JE=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/oneview/resource_server_profile.go
+++ b/oneview/resource_server_profile.go
@@ -40,6 +40,12 @@ func resourceServerProfile() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"force_flags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"boot": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -1970,7 +1976,31 @@ func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	//Cleaning up SP  by removing spt related fields
 	config.ovClient.Cleanup(&serverProfile)
-	err := config.ovClient.SubmitNewProfile(serverProfile)
+
+	providedForceFlags := d.Get("force_flags").([]interface{})
+	forceFlags := []ov.ForceFlag{}
+
+	for _, f := range providedForceFlags {
+		// see https://github.com/HewlettPackard/oneview-golang/blob/master/ov/profiles.go#L52 for supported force flags
+		switch f.(string) {
+		case "ignoreSANWarnings":
+			forceFlags = append(forceFlags, ov.ForceIgnoreSANWarnings)
+		case "ignoreServerHealth":
+			forceFlags = append(forceFlags, ov.ForceIgnoreServerHealth)
+		case "ignoreLSWarnings":
+			forceFlags = append(forceFlags, ov.ForceIgnoreLSWarnings)
+		case "all":
+			forceFlags = append(forceFlags, ov.ForceIgnoreAll)
+		case "none":
+			forceFlags = append(forceFlags, ov.ForceIgnoreNone)
+		default:
+			return fmt.Errorf("invalid force flag." +
+				"(supported values: \"ignoreSANWarnings\", \"ignoreServerHealth\", \"ignoreLSWarnings\", \"all\", \"none\")")
+		}
+	}
+
+	err := config.ovClient.SubmitNewProfile(serverProfile, forceFlags...)
+
 	d.SetId(d.Get("name").(string))
 
 	if err != nil {
@@ -1981,6 +2011,7 @@ func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error
 			return err
 		}
 	}
+
 	return resourceServerProfileRead(d, meta)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 # cloud.google.com/go/storage v1.10.0
 cloud.google.com/go/storage
-# github.com/HewlettPackard/oneview-golang v8.6.0+incompatible
+# github.com/HewlettPackard/oneview-golang v8.6.1-0.20231109094213-30a3fb89caf6+incompatible
 ## explicit
 github.com/HewlettPackard/oneview-golang/liboneview
 github.com/HewlettPackard/oneview-golang/ov


### PR DESCRIPTION
This PR adds a list of strings attribute called `force_flag` to the `oneview_server_profile`-resource, that was added in https://github.com/HewlettPackard/oneview-golang/pull/403:

```hcl
data "oneview_server_profile_template" "template" {
  # template name: <Product-Name>_<config_pattern>_<firmware>
  # beispiel: ProLiant DL20 Gen10 Plus -> ProLiant_DL20_Gen10_Plus_default_latest
  name = "${var.product_name}_${var.config_pattern}_${var.firmware_baseline}"
}

resource "oneview_server_profile" "this" {
  name                 = var.hostname
  hardware_name        = var.hostname
  server_hardware_type = data.oneview_server_profile_template.template.server_hardware_type
  template             = data.oneview_server_profile_template.template.name

  force_flags = ["ignoreServerHealth"]
}
```

I have tested the change and it works as expected:

```bash
data.http.ilo["XXXXXXXX"]: Reading...
data.vault_generic_secret.lxca_creds: Reading...
data.vault_generic_secret.oneview_creds: Reading...
module.bm4x_server_project.data.vault_generic_secret.appliance_pw["XXXXXXXX"]: Reading...
module.bm4x_server_project.data.vault_generic_secret.user_pass["XXXXXXXX-bm4xoperator"]: Reading...
module.bm4x_server_project.module.hpe_server["XXXXXXXX"].data.oneview_server_profile_template.template: Reading...
module.bm4x_server_project.data.vault_generic_secret.user_pass["XXXXXXXX-bm4xoperator"]: Read complete after 0s [id=91195/bamberg-10/bm4x/compute/XXXXXXXX/users/admin]
module.bm4x_server_project.data.vault_generic_secret.appliance_pw["XXXXXXXX"]: Read complete after 0s [id=91195/bamberg-10/bm4x/compute/XXXXXXXX/users/appliance]
module.bm4x_server_project.module.hpe_server["XXXXXXXX"].data.oneview_server_profile_template.template: Read complete after 0s [id=ProLiant_DL20_Gen10_Plus_default_latest]
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
Terraform will perform the following actions:
  # module.bm4x_server_project.module.hpe_server["XXXXXXXX"].oneview_server_profile.this will be created
  + resource "oneview_server_profile" "this" {
      + affinity                      = (known after apply)
      + associated_server             = (known after apply)
      + category                      = (known after apply)
      + created                       = (known after apply)
      + description                   = (known after apply)
      + enclosure_bay                 = (known after apply)
      + enclosure_group               = (known after apply)
      + enclosure_uri                 = (known after apply)
      + etag                          = (known after apply)
      + force_flags                   = [
          + "ignoreServerHealth",
        ]
      + hardware_name                 = "bmbg10com5i0t"
      + hardware_uri                  = (known after apply)
      + hide_unused_flex_nics         = (known after apply)
      + id                            = (known after apply)
      + ilo_ip                        = (known after apply)
      + in_progress                   = (known after apply)
      + iscsi_initiator_name          = (known after apply)
      + iscsi_initiator_name_type     = (known after apply)
      + mac_type                      = (known after apply)
      + modified                      = (known after apply)
      + name                          = "bmbg10com5i0t"
      + profile_uuid                  = (known after apply)
      + public_mac                    = (known after apply)
      + public_slot_id                = (known after apply)
      + refresh_state                 = (known after apply)
      + scopes_uri                    = (known after apply)
      + serial_number                 = (known after apply)
      + serial_number_type            = (known after apply)
      + server_hardware_reapply_state = (known after apply)
      + server_hardware_type          = "DL20 Gen10 Plus"
      + server_hardware_type_uri      = (known after apply)
      + service_manager               = (known after apply)
      + state                         = (known after apply)
      + status                        = (known after apply)
      + task_uri                      = (known after apply)
      + template                      = "ProLiant_DL20_Gen10_Plus_default_latest"
      + template_compliance           = (known after apply)
      + type                          = (known after apply)
      + uri                           = (known after apply)
      + uuid                          = (known after apply)
      + wwn_type                      = (known after apply)
    }
Plan: 1 to add, 0 to change, 0 to destroy.

module.bm4x_server_project.module.hpe_server["XXXXXXXX"].oneview_server_profile.this: Creating...
module.bm4x_server_project.module.hpe_server["XXXXXXXX"].oneview_server_profile.this: Still creating... [10s elapsed]
[...]
module.bm4x_server_project.module.hpe_server["XXXXXXXX"].oneview_server_profile.this: Creation complete after 8m52s [id=bmbg10com5i0t]
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
---
fixes #548.
