### PR TITLE
Added the output of MAC addresses for interfaces

### DIFF
--- a/oneview/data_source_server_profile.go
+++ b/oneview/data_source_server_profile.go
@@ -1361,6 +1361,7 @@ func dataSourceServerProfileRead(d *schema.ResourceData, meta interface{}) error
 				"name":           connection.Name,
 				"isolated_trunk": connection.IsolatedTrunk,
 				"lag_name":       connection.LagName,
+				"mac":            connection.MAC,
 				"mac_type":       connection.MacType,
 				"managed":        connection.Managed,
 				"network_name":   connection.NetworkName,

--- a/oneview/resource_server_profile.go
+++ b/oneview/resource_server_profile.go
@@ -2457,6 +2457,7 @@ func resourceServerProfileRead(d *schema.ResourceData, meta interface{}) error {
 				"isolated_trunk":         connection.IsolatedTrunk,
 				"lag_name":               connection.LagName,
 				"mac_type":               connection.MacType,
+				"mac":                    connection.MAC,
 				"managed":                connection.Managed,
 				"network_name":           connection.NetworkName,
 				"boot":                   connectionBoot,


### PR DESCRIPTION
### Description
Add the MAC address of interfaces to object when creating a new resource and when querying an existing resource.

### Issues Resolved
Resolves issue #552 

I had to use the OV8.6_Validation branch since the master branch at the time was compiling but would fail on apply.