### PR TITLE
Added support for hostNVMeQualifiedNameType and hostNVMeQualifiedName

### DIFF
--- a/oneview/data_source_server_profile.go
+++ b/oneview/data_source_server_profile.go
@@ -32,6 +32,14 @@ func dataSourceServerProfile() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"host_nvme_qualified_name_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_nvme_qualified_name": {
+				Type:     schema.TypeString,
+				Computed: true,				
+			},
 			"bios_option": {
 				Type:     schema.TypeSet,
 				Optional: true,

--- a/oneview/resource_server_profile.go
+++ b/oneview/resource_server_profile.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"io/ioutil"
 
 	"github.com/HewlettPackard/oneview-golang/ov"
 	"github.com/HewlettPackard/oneview-golang/utils"
@@ -1014,6 +1015,16 @@ func resourceServerProfile() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"host_nvme_qualified_name_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"host_nvme_qualified_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,		
+			},
 			"management_processor": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -1366,6 +1377,8 @@ func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error
 
 	serverProfile.Type = d.Get("type").(string)
 	serverProfile.Name = d.Get("name").(string)
+	serverProfile.HostNVMeQualifiedNameType = d.Get("host_nvme_qualified_name_type").(string)
+	serverProfile.HostNVMeQualifiedName = d.Get("host_nvme_qualified_name").(string)
 
 	var serverHardware ov.ServerHardware
 	if val, ok := d.GetOk("hardware_name"); ok {
@@ -2080,6 +2093,8 @@ func resourceServerProfileRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("server_hardware_type", serverHardwareType.Name)
 	d.Set("affinity", serverProfile.Affinity)
+	d.Set("host_nvme_qualified_name_type", serverProfile.HostNVMeQualifiedNameType)
+	d.Set("host_nvme_qualified_name", serverProfile.HostNVMeQualifiedName)
 	d.Set("serial_number_type", serverProfile.SerialNumberType)
 	d.Set("wwn_type", serverProfile.WWNType)
 	d.Set("mac_type", serverProfile.MACType)
@@ -2874,6 +2889,16 @@ func resourceServerProfileUpdate(d *schema.ResourceData, meta interface{}) error
 			serverProfile.SerialNumberType = val.(string)
 		}
 
+		if d.HasChange("host_nvme_qualified_name_type") {
+			val := d.Get("host_nvme_qualified_name_type").(string)
+			serverProfile.HostNVMeQualifiedNameType = val
+		}
+
+		if d.HasChange("host_nvme_qualified_name") {
+			val := d.Get("host_nvme_qualified_name")
+			serverProfile.HostNVMeQualifiedName = val.(string)
+		}
+
 		if d.HasChange("wwn_type") {
 			val := d.Get("wwn_type")
 			serverProfile.WWNType = val.(string)
@@ -3496,6 +3521,9 @@ func resourceServerProfileUpdate(d *schema.ResourceData, meta interface{}) error
 			}
 			serverProfile.SanStorage.VolumeAttachments = volumeAttachments
 		}
+		file, _ := json.MarshalIndent(serverProfile, "", " ")
+           _ = ioutil.WriteFile("test.json", file, 0644)
+
 
 		err = config.ovClient.UpdateServerProfile(serverProfile)
 


### PR DESCRIPTION
### Description
Starting from OneView version 8.40, the HostNVMeQualifiedNameType field has been made mandatory during server profile update operations. If this field is not explicitly included in the update request, OneView returns an error.
Currently, the Golang and Terraform SDK does not include the HostNVMeQualifiedNameType attribute, which leads to failure when attempting to update an existing server profile.
During profile creation, if this field is not specified by the user, OneView automatically sets it to "AutoGenerated". However, during updates, OneView expects the value to be explicitly provided.

This PR addresses the above mentioned issue

### Issues Resolved
[List any issues this PR will resolve. e.g., Fixes #01]

### Check List
- [ ] New functionality includes testing.
  - [ ]  All tests pass for go 1.11 + gofmt checks.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.